### PR TITLE
fix(transport): SharedUDP stdlib + parallel SO_REUSEPORT ingress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
 LDFLAGS := -ldflags "-X main.Version=$(VERSION) -X main.BuildDate=$(BUILD_DATE) -X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT) -X main.GoVersion=$(GO_VERSION) -X main.BuildOS=$(OS) -X main.BuildArch=$(ARCH)"
 
-.PHONY: build dynamic package package-deb package-rpm benchmark clean
+.PHONY: build dynamic package package-deb package-rpm benchmark bench-transport clean
 
 build:
 	mkdir -p $(DIST)
@@ -30,6 +30,10 @@ package-rpm:
 
 benchmark:
 	scripts/benchmark-sipp-vs-gossipper.sh "$${BENCH_TARGET:-127.0.0.1:5060}" "$${BENCH_CALLS:-1000}" "$${BENCH_RATE:-50}" "$${BENCH_CONCURRENT:-100}"
+
+# UDP SharedUDP / reuseport benches (see scripts/bench_transport.sh).
+bench-transport:
+	bash scripts/bench_transport.sh
 
 clean:
 	rm -rf $(DIST)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/sys v0.42.0
 	golang.org/x/text v0.35.0
 )
 
@@ -33,7 +34,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -5,6 +5,15 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
+)
+
+const (
+	maxUDPDatagram = 65535
+	// inboundChanDepth is the depth of SharedUDP Receive channel (was 128 before widening).
+	inboundChanDepth = 512
+	udpSocketRecvBuf = 8 * 1024 * 1024
+	udpSocketSendBuf = 1024 * 1024
 )
 
 type Packet struct {
@@ -12,10 +21,14 @@ type Packet struct {
 	Addr *net.UDPAddr
 }
 
+// SharedUDP is a UDP socket shared by multiple logical SIP flows (gossipper UAC/UAS).
+// Uses the standard library listener plus a read loop (same model as transport mode "un").
 type SharedUDP struct {
-	conn      *net.UDPConn
-	incoming  chan Packet
-	closeOnce sync.Once
+	conn         *net.UDPConn
+	incoming     chan Packet
+	closeOnce    sync.Once
+	incomingOnce sync.Once
+	closed       atomic.Bool
 }
 
 func NewSharedUDP(localAddr string) (*SharedUDP, error) {
@@ -27,29 +40,55 @@ func NewSharedUDP(localAddr string) (*SharedUDP, error) {
 	if err != nil {
 		return nil, err
 	}
+	_ = conn.SetReadBuffer(udpSocketRecvBuf)
+	_ = conn.SetWriteBuffer(udpSocketSendBuf)
+
 	s := &SharedUDP{
 		conn:     conn,
-		incoming: make(chan Packet, 128),
+		incoming: make(chan Packet, inboundChanDepth),
 	}
 	go s.readLoop()
 	return s, nil
 }
 
 func (s *SharedUDP) readLoop() {
-	buffer := make([]byte, 65535)
+	buffer := make([]byte, maxUDPDatagram)
 	for {
 		n, addr, err := s.conn.ReadFromUDP(buffer)
 		if err != nil {
-			close(s.incoming)
+			s.shutdownIncoming()
 			return
+		}
+		if n <= 0 || n > maxUDPDatagram {
+			continue
+		}
+		if addr == nil {
+			continue
 		}
 		payload := make([]byte, n)
 		copy(payload, buffer[:n])
-		s.incoming <- Packet{Data: payload, Addr: addr}
+		p := Packet{Data: payload, Addr: addr}
+		select {
+		case s.incoming <- p:
+		default:
+			select {
+			case s.incoming <- p:
+			default:
+			}
+		}
 	}
 }
 
+func (s *SharedUDP) shutdownIncoming() {
+	s.incomingOnce.Do(func() {
+		close(s.incoming)
+	})
+}
+
 func (s *SharedUDP) Send(payload []byte, addr *net.UDPAddr) error {
+	if s.closed.Load() {
+		return net.ErrClosed
+	}
 	_, err := s.conn.WriteToUDP(payload, addr)
 	return err
 }
@@ -59,7 +98,7 @@ func (s *SharedUDP) Receive() <-chan Packet {
 }
 
 func (s *SharedUDP) LocalPort() int {
-	if addr, ok := s.conn.LocalAddr().(*net.UDPAddr); ok {
+	if addr, ok := s.conn.LocalAddr().(*net.UDPAddr); ok && addr != nil {
 		return addr.Port
 	}
 	return 0
@@ -68,7 +107,9 @@ func (s *SharedUDP) LocalPort() int {
 func (s *SharedUDP) Close() error {
 	var err error
 	s.closeOnce.Do(func() {
+		s.closed.Store(true)
 		err = s.conn.Close()
+		s.shutdownIncoming()
 	})
 	return err
 }

--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -4,17 +4,29 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
 
 const (
 	maxUDPDatagram = 65535
-	// inboundChanDepth is the depth of SharedUDP Receive channel (was 128 before widening).
+	// inboundChanDepth is the base depth of SharedUDP Receive channel per receiver slot (scaled below).
 	inboundChanDepth = 512
+	maxInboundChan   = 8192
 	udpSocketRecvBuf = 8 * 1024 * 1024
 	udpSocketSendBuf = 1024 * 1024
+	// maxUDPReceivers caps parallel SO_REUSEPORT listeners (kernel spreads ingress across them).
+	maxUDPReceivers = 16
+	envUDPReceivers = "GOSSIPPER_UDP_RECEIVERS"
 )
+
+// Linux tuning hints for lab/production high ingress:
+//   sysctl net.core.rmem_max, net.core.netdev_max_backlog; optionally busy polling on NIC path.
+// Parallel listeners: set GOSSIPPER_UDP_RECEIVERS to match core count (capped at maxUDPReceivers).
 
 type Packet struct {
 	Data []byte
@@ -22,39 +34,108 @@ type Packet struct {
 }
 
 // SharedUDP is a UDP socket shared by multiple logical SIP flows (gossipper UAC/UAS).
-// Uses the standard library listener plus a read loop (same model as transport mode "un").
+// On supported platforms it may use several listeners with SO_REUSEPORT and one merged Receive channel.
 type SharedUDP struct {
-	conn         *net.UDPConn
-	incoming     chan Packet
-	closeOnce    sync.Once
-	incomingOnce sync.Once
-	closed       atomic.Bool
+	conns         []*net.UDPConn
+	incoming      chan Packet
+	closeOnce     sync.Once
+	incomingOnce  sync.Once
+	closed        atomic.Bool
+	receiverCount int
 }
 
+// NewSharedUDP binds localAddr and starts ingress goroutines. Parallelism is controlled by
+// environment variable GOSSIPPER_UDP_RECEIVERS (integer): 0 or unset means auto (see effectiveReceivers).
 func NewSharedUDP(localAddr string) (*SharedUDP, error) {
+	return NewSharedUDPWithReceivers(localAddr, receiversFromEnv())
+}
+
+// NewSharedUDPWithReceivers is like NewSharedUDP but takes an explicit receiver count (0 = auto).
+// Intended for tests; production tuning uses GOSSIPPER_UDP_RECEIVERS.
+func NewSharedUDPWithReceivers(localAddr string, receivers int) (*SharedUDP, error) {
 	addr, err := net.ResolveUDPAddr("udp", localAddr)
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.ListenUDP("udp", addr)
+	n := effectiveReceivers(receivers)
+	conns, err := listenParallelUDP(addr, n)
 	if err != nil {
 		return nil, err
 	}
-	_ = conn.SetReadBuffer(udpSocketRecvBuf)
-	_ = conn.SetWriteBuffer(udpSocketSendBuf)
-
+	chDepth := inboundChanDepthFor(n)
 	s := &SharedUDP{
-		conn:     conn,
-		incoming: make(chan Packet, inboundChanDepth),
+		conns:         conns,
+		incoming:      make(chan Packet, chDepth),
+		receiverCount: len(conns),
 	}
-	go s.readLoop()
+	for _, c := range conns {
+		go s.readLoop(c)
+	}
 	return s, nil
 }
 
-func (s *SharedUDP) readLoop() {
+// ReceiverCount returns how many parallel UDP listeners were started (SO_REUSEPORT fan-in).
+func (s *SharedUDP) ReceiverCount() int {
+	return s.receiverCount
+}
+
+func receiversFromEnv() int {
+	v := strings.TrimSpace(os.Getenv(envUDPReceivers))
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+func effectiveReceivers(requested int) int {
+	if requested <= 0 {
+		requested = autoReceiverCount()
+	}
+	return clampReceivers(requested)
+}
+
+func autoReceiverCount() int {
+	n := runtime.NumCPU()
+	if n < 1 {
+		n = 1
+	}
+	return clampReceivers(n)
+}
+
+func clampReceivers(n int) int {
+	if n < 1 {
+		n = 1
+	}
+	if n > maxUDPReceivers {
+		n = maxUDPReceivers
+	}
+	return maybeSingleReceiverOS(n)
+}
+
+func inboundChanDepthFor(receivers int) int {
+	d := inboundChanDepth * receivers
+	if d > maxInboundChan {
+		d = maxInboundChan
+	}
+	if d < inboundChanDepth {
+		d = inboundChanDepth
+	}
+	return d
+}
+
+func tuneUDPConn(c *net.UDPConn) {
+	_ = c.SetReadBuffer(udpSocketRecvBuf)
+	_ = c.SetWriteBuffer(udpSocketSendBuf)
+}
+
+func (s *SharedUDP) readLoop(conn *net.UDPConn) {
 	buffer := make([]byte, maxUDPDatagram)
 	for {
-		n, addr, err := s.conn.ReadFromUDP(buffer)
+		n, addr, err := conn.ReadFromUDP(buffer)
 		if err != nil {
 			s.shutdownIncoming()
 			return
@@ -89,7 +170,10 @@ func (s *SharedUDP) Send(payload []byte, addr *net.UDPAddr) error {
 	if s.closed.Load() {
 		return net.ErrClosed
 	}
-	_, err := s.conn.WriteToUDP(payload, addr)
+	if len(s.conns) == 0 {
+		return errors.New("transport: UDP not initialized")
+	}
+	_, err := s.conns[0].WriteToUDP(payload, addr)
 	return err
 }
 
@@ -98,7 +182,10 @@ func (s *SharedUDP) Receive() <-chan Packet {
 }
 
 func (s *SharedUDP) LocalPort() int {
-	if addr, ok := s.conn.LocalAddr().(*net.UDPAddr); ok && addr != nil {
+	if len(s.conns) == 0 {
+		return 0
+	}
+	if addr, ok := s.conns[0].LocalAddr().(*net.UDPAddr); ok && addr != nil {
 		return addr.Port
 	}
 	return 0
@@ -108,7 +195,11 @@ func (s *SharedUDP) Close() error {
 	var err error
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
-		err = s.conn.Close()
+		for _, c := range s.conns {
+			if e := c.Close(); e != nil && err == nil {
+				err = e
+			}
+		}
 		s.shutdownIncoming()
 	})
 	return err

--- a/internal/transport/udp_bench_test.go
+++ b/internal/transport/udp_bench_test.go
@@ -1,0 +1,75 @@
+package transport
+
+import (
+	"net"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+// BenchmarkSharedUDP_NewClose measures bind/teardown cost with parallel reuseport listeners.
+func BenchmarkSharedUDP_NewClose(b *testing.B) {
+	n := 8
+	if runtime.NumCPU() < n {
+		n = runtime.NumCPU()
+	}
+	if n < 1 {
+		n = 1
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s, err := NewSharedUDPWithReceivers("127.0.0.1:0", n)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = s.Close()
+	}
+}
+
+// BenchmarkSharedUDP_RoundTrip sends UDP to self through SharedUDP (listen → readLoop → channel).
+func BenchmarkSharedUDP_RoundTrip(b *testing.B) {
+	if testing.Short() {
+		b.Skip()
+	}
+	const payloadLen = 512
+	payload := make([]byte, payloadLen)
+
+	rc := runtime.NumCPU()
+	if rc > maxUDPReceivers {
+		rc = maxUDPReceivers
+	}
+	if rc < 1 {
+		rc = 1
+	}
+
+	s, err := NewSharedUDPWithReceivers("127.0.0.1:0", rc)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer s.Close()
+
+	la := net.JoinHostPort("127.0.0.1", strconv.Itoa(s.LocalPort()))
+	remote, err := net.ResolveUDPAddr("udp", la)
+	if err != nil {
+		b.Fatal(err)
+	}
+	conn, err := net.DialUDP("udp", nil, remote)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+
+	b.SetBytes(payloadLen)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := conn.Write(payload); err != nil {
+			b.Fatal(err)
+		}
+		p := <-s.Receive()
+		if len(p.Data) != payloadLen {
+			b.Fatalf("got len %d want %d", len(p.Data), payloadLen)
+		}
+	}
+}

--- a/internal/transport/udp_reuseport.go
+++ b/internal/transport/udp_reuseport.go
@@ -1,0 +1,66 @@
+//go:build linux || darwin || freebsd || openbsd || netbsd
+
+package transport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func listenParallelUDP(addr *net.UDPAddr, receivers int) ([]*net.UDPConn, error) {
+	if receivers <= 1 {
+		c, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		tuneUDPConn(c)
+		return []*net.UDPConn{c}, nil
+	}
+
+	lc := net.ListenConfig{
+		Control: reusePortControl,
+	}
+	out := make([]*net.UDPConn, 0, receivers)
+	for i := 0; i < receivers; i++ {
+		p, err := lc.ListenPacket(context.Background(), "udp", addr.String())
+		if err != nil {
+			for _, q := range out {
+				_ = q.Close()
+			}
+			return nil, err
+		}
+		uc, ok := p.(*net.UDPConn)
+		if !ok {
+			_ = p.Close()
+			for _, q := range out {
+				_ = q.Close()
+			}
+			return nil, errors.New("transport: ListenPacket is not *net.UDPConn")
+		}
+		tuneUDPConn(uc)
+		out = append(out, uc)
+	}
+	return out, nil
+}
+
+func reusePortControl(network, address string, c syscall.RawConn) error {
+	var opErr error
+	err := c.Control(func(fd uintptr) {
+		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); e != nil {
+			opErr = e
+			return
+		}
+		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	})
+	if err != nil {
+		return err
+	}
+	return opErr
+}
+
+// maybeSingleReceiverOS is a no-op on this build: reuseport is available.
+func maybeSingleReceiverOS(n int) int { return n }

--- a/internal/transport/udp_reuseport_fallback.go
+++ b/internal/transport/udp_reuseport_fallback.go
@@ -1,0 +1,17 @@
+//go:build !(linux || darwin || freebsd || openbsd || netbsd)
+
+package transport
+
+import "net"
+
+func listenParallelUDP(addr *net.UDPAddr, receivers int) ([]*net.UDPConn, error) {
+	_, _ = receivers, receivers
+	c, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	tuneUDPConn(c)
+	return []*net.UDPConn{c}, nil
+}
+
+func maybeSingleReceiverOS(n int) int { return 1 }

--- a/internal/transport/udp_test.go
+++ b/internal/transport/udp_test.go
@@ -1,6 +1,12 @@
 package transport
 
-import "testing"
+import (
+	"net"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
 
 func TestSharedUDPOpenClose(t *testing.T) {
 	s, err := NewSharedUDP("127.0.0.1:0")
@@ -9,5 +15,36 @@ func TestSharedUDPOpenClose(t *testing.T) {
 	}
 	if err := s.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSharedUDPParallelReceivers(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" || runtime.GOOS == "wasip1" {
+		t.Skip("SO_REUSEPORT parallel listeners not used on this platform")
+	}
+	s, err := NewSharedUDPWithReceivers("127.0.0.1:0", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if n := s.ReceiverCount(); n < 2 {
+		t.Fatalf("expected at least 2 parallel receivers on unix, got %d", n)
+	}
+	la := net.JoinHostPort("127.0.0.1", strconv.Itoa(s.LocalPort()))
+	remote, err := net.ResolveUDPAddr("udp", la)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("ping")
+	if err := s.Send(payload, remote); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case p := <-s.Receive():
+		if string(p.Data) != "ping" {
+			t.Fatalf("payload = %q", p.Data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for self-sent UDP packet")
 	}
 }

--- a/internal/transport/udp_test.go
+++ b/internal/transport/udp_test.go
@@ -1,0 +1,13 @@
+package transport
+
+import "testing"
+
+func TestSharedUDPOpenClose(t *testing.T) {
+	s, err := NewSharedUDP("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/bench_transport.sh
+++ b/scripts/bench_transport.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# UDP transport microbenchmarks (SharedUDP / reuseport).
+# Usage:
+#   ./scripts/bench_transport.sh
+#   BENCHTIME=3s BENCH=BenchmarkSharedUDP_RoundTrip ./scripts/bench_transport.sh
+#   CPUPROFILE=/tmp/transport.cpu ./scripts/bench_transport.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BENCHTIME="${BENCHTIME:-1s}"
+BENCH="${BENCH:-.}"
+PKG="./internal/transport/..."
+
+cmd=(go test "$PKG" -run='^$' -bench="$BENCH" -benchmem -benchtime="$BENCHTIME" -count=1)
+
+if [[ -n "${CPUPROFILE:-}" ]]; then
+	cmd+=(-cpuprofile="$CPUPROFILE")
+fi
+
+exec "${cmd[@]}"


### PR DESCRIPTION
## Summary
- **SharedUDP** uses `net.ListenUDP` + read loops (drops prior gnet path that caused first-packet latency issues).
- Optional **parallel ingress** on Unix/BSD: multiple listeners with **SO_REUSEPORT**, kernel spreads packets; merged into one `Receive()` channel.
- **`GOSSIPPER_UDP_RECEIVERS`** (integer): `0` / unset = auto `min(NumCPU, 16)`. Inbound channel depth scales (cap 8192).
- Build tags: unix reuseport vs **fallback** single socket (Windows / unsupported).

## Tooling
- `make bench-transport` / `scripts/bench_transport.sh` — microbenchmarks; env `BENCHTIME`, `BENCH`, optional `CPUPROFILE`.

## Tests
`go test ./...`