### PR TITLE
fix(template): resolve -inf CSV from CWD, not from scenario directory

### DIFF
--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -708,11 +708,17 @@ func renderFieldTokenWithVariables(key, basePath string, callNumber int, variabl
 	}
 	parsed := parseKeyParams(params)
 	name := strings.TrimSpace(parsed["file"])
+	// csvBasePath is the directory used to resolve the CSV file.
+	// Files named inline (file=) are relative to the scenario directory (basePath).
+	// The default injection file (-inf) is specified relative to the CWD, so use
+	// an empty base so resolvePath does not prepend the scenario directory.
+	csvBasePath := basePath
 	if name == "" {
 		name = strings.TrimSpace(defaultInjectionFile)
 		if name == "" {
 			return "", false
 		}
+		csvBasePath = ""
 	}
 	lineNumber := callNumber
 	explicitPhysicalLine := false
@@ -725,7 +731,7 @@ func renderFieldTokenWithVariables(key, basePath string, callNumber int, variabl
 		explicitPhysicalLine = true
 	}
 
-	record, ok, err := csvRecordAt(basePath, name, lineNumber, overrides, explicitPhysicalLine)
+	record, ok, err := csvRecordAt(csvBasePath, name, lineNumber, overrides, explicitPhysicalLine)
 	if err != nil || !ok {
 		return "", false
 	}

--- a/internal/template/render_injection_test.go
+++ b/internal/template/render_injection_test.go
@@ -142,3 +142,28 @@ func TestRenderFieldBeyondRowWidthReturnsEmpty(t *testing.T) {
 		t.Fatalf("field1: got %q want empty", got1)
 	}
 }
+
+func TestRenderFieldDefaultInjectionFileIsRelativeToCWDNotScenarioDir(t *testing.T) {
+// The -inf CSV is relative to the process CWD; the scenario XML may be in a
+// subdirectory, making BasePath a sub-path like "./scenarios".  Field tokens
+// must still resolve the injection file from CWD, not from BasePath.
+csvDir := t.TempDir()
+scenarioDir := t.TempDir() // simulates "./scenarios" — a different directory
+csvPath := filepath.Join(csvDir, "data.csv")
+if err := os.WriteFile(csvPath, []byte("SEQUENTIAL\nhello;world\n"), 0o644); err != nil {
+t.Fatal(err)
+}
+ctx := Context{
+BasePath:          scenarioDir, // scenario lives in a subdirectory
+CallNumber:        1,
+InjectionFile:     csvPath, // -inf is absolute (or relative to CWD)
+CSVFieldOverrides: make(map[string]map[int]map[int]string),
+}
+got, err := ctx.RenderStrict("[field0]")
+if err != nil {
+t.Fatalf("[field0] with BasePath != csvDir: %v", err)
+}
+if got != "hello" {
+t.Fatalf("field0: got %q want hello", got)
+}
+}


### PR DESCRIPTION
When the scenario XML is in a subdirectory (./scenarios/foo.xml), BasePath is set to "./scenarios". [fieldN] tokens with no explicit file= use the CLI -inf path as the default, but that path is relative to CWD — not to the scenario directory. resolvePath("scenarios", "data.csv") was producing "scenarios/data.csv", which doesn't exist.