### PR TITLE
fix(engine): fix optional recv timer and pending chain semantics

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1625,9 +1625,13 @@ func (e *Engine) executeCall(
 				if cmd.RecvResp != "" && sip.ResponseStatusMatches(*m, cmd.RecvResp) && !sip.MatchRecv(*m, cmd.RecvReq, cmd.RecvResp, lastSent) {
 					e.emitRecvCSeqReject(callNumber, renderCtx.CallID, cmd, m, lastSent)
 				}
-				e.traceUnexpectedSIP(callNumber, cmd, *m)
-				e.traceCountUnexpected(cmd.Index)
-				sawUnexpectedSIP = true
+				if !cmd.Optional {
+					// For optional recvs, a mismatched message is just being
+					// deferred to a later recv — not truly unexpected.
+					e.traceUnexpectedSIP(callNumber, cmd, *m)
+					e.traceCountUnexpected(cmd.Index)
+					sawUnexpectedSIP = true
+				}
 				if unexpMainIndex >= 0 && unexpectedForMain == nil {
 					cpy := m.Copy()
 					unexpectedForMain = &cpy

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -40,6 +40,11 @@ var (
 	parseHeadersLinesPool   = sync.Pool{New: func() interface{} { return new([]string) }}
 )
 
+// sipTimerB is RFC 3261 Timer B: the INVITE client transaction timeout
+// (64 * T1 = 64 * 500ms = 32s). Used as a floor for optional recv timeouts
+// so INVITE response chains don't abort before the transaction can complete.
+const sipTimerB = 64 * 500 * time.Millisecond
+
 type Config struct {
 	Scenario         scenario.Scenario
 	Transport        string
@@ -1611,6 +1616,10 @@ func (e *Engine) executeCall(
 			var unexpectedForMain *sip.Message
 			msg, err := e.waitForMatch(ctx, receiveWithPending, cmd, lastSent, send, retransmit, recvTimeout, func(m *sip.Message, fromPending bool) bool {
 				if fromPending {
+					if cmd.Optional {
+						// Re-queue back so subsequent optional recvs can try it.
+						pending = append(pending, m)
+					}
 					return false
 				}
 				if cmd.RecvResp != "" && sip.ResponseStatusMatches(*m, cmd.RecvResp) && !sip.MatchRecv(*m, cmd.RecvReq, cmd.RecvResp, lastSent) {
@@ -1636,7 +1645,7 @@ func (e *Engine) executeCall(
 					continue
 				}
 				if cmd.Optional {
-					index = resolveNext(index, cmd, store, e.random)
+					index = index + 1
 					continue
 				}
 				if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
@@ -1751,11 +1760,14 @@ func effectiveSIPRecvTimeout(cmd scenario.Command, defaultRecv, recvBYEFloor tim
 	if cmd.Timeout > 0 {
 		return cmd.Timeout
 	}
-	if cmd.Optional {
-		return 250 * time.Millisecond
-	}
 	out := defaultRecv
-	if recvBYEFloor > 0 && strings.EqualFold(strings.TrimSpace(cmd.RecvReq), "BYE") && out < recvBYEFloor {
+	if cmd.Optional && out < sipTimerB {
+		// Optional recvs must wait at least RFC 3261 Timer B so that slow
+		// INVITE transactions (TLS + media processing) have time to deliver
+		// their 200 OK before the scenario gives up.
+		out = sipTimerB
+	}
+	if !cmd.Optional && recvBYEFloor > 0 && strings.EqualFold(strings.TrimSpace(cmd.RecvReq), "BYE") && out < recvBYEFloor {
 		out = recvBYEFloor
 	}
 	return out
@@ -1930,10 +1942,9 @@ func (e *Engine) waitForMatch(
 			}
 			if cmd.Optional {
 				// Free msg only if stash did NOT take ownership.
-				// When stash != nil and fromPending is false, stash stored msg in
-				// pending (caller will drain it next). When fromPending is true
-				// the message was dequeued from pending and stash returned early.
-				if stash == nil || fromPending {
+				// When stash is present it re-queues the message into pending
+				// (even when fromPending is true) so the next recv can try it.
+				if stash == nil {
 					sip.PutMessage(msg)
 				}
 				return nil, errOptionalRecvMismatch
@@ -1944,7 +1955,7 @@ func (e *Engine) waitForMatch(
 			continue
 		}
 
-		if errors.Is(err, context.DeadlineExceeded) && retrans > 0 && len(lastSent) > 0 && time.Now().Before(deadline) {
+		if errors.Is(err, context.DeadlineExceeded) && retrans > 0 && len(lastSent) > 0 && time.Now().Before(deadline) && ctx.Err() == nil {
 			if sendErr := send(lastSent); sendErr != nil {
 				return nil, sendErr
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -5358,8 +5358,8 @@ func TestEffectiveSIPRecvTimeoutBYE(t *testing.T) {
 		t.Fatalf("INVITE: got %v", got)
 	}
 	cmd = scenario.Command{RecvReq: "BYE", Optional: true}
-	if got := effectiveSIPRecvTimeout(cmd, 5*time.Second, 90*time.Second); got != 250*time.Millisecond {
-		t.Fatalf("optional BYE: got %v", got)
+	if got := effectiveSIPRecvTimeout(cmd, 5*time.Second, 90*time.Second); got != sipTimerB {
+		t.Fatalf("optional BYE: got %v, want %v", got, sipTimerB)
 	}
 	cmd = scenario.Command{RecvReq: "BYE"}
 	if got := effectiveSIPRecvTimeout(cmd, 100*time.Second, 90*time.Second); got != 100*time.Second {


### PR DESCRIPTION
Several related bugs in the optional <recv> handling caused scenarios to fail silently:

   1. 250 ms timeout was too short — optional recvs used a hard-coded 250 ms floor, causing them to expire almost immediately on TLS connections with media processing (rtpengine, FreeSWITCH). The whole provisional-response chain (100/180/183) timed out before the 200 OK could 
  arrive.
   2. next= followed on timeout — on optional recv timeout or mismatch, the engine called resolveNext() which follows the next= label. In SIPp semantics, next= should only fire on successful receipt; on timeout/mismatch execution must advance sequentially to index+1.
   3. Pending messages lost across optional recv chain — when a message (e.g. 200 OK) arrived while at an optional recv for a different code (e.g. 183), it was stashed but then freed before the next recv could consume it, causing the mandatory recv 200 to time out.
   4. Retransmit loop continued after context cancellation — the UDP retransmit loop lacked a ctx.Err() == nil guard, causing it to keep retransmitting and looping even after the outer context was cancelled, which caused tests to run for 32 s.

  **Fix:**
   - Replace the 250 ms floor with RFC 3261 Timer B (64 × T1 = 32 s) as the minimum wait for optional recvs, so INVITE transactions have time to deliver their final response.
   - On optional recv timeout/mismatch, advance to index + 1 instead of calling resolveNext().
   - When a pending message mismatches an optional recv, re-queue it back into pending so the next recv in the chain can try it.
   - In waitForMatch, do not free the message when a stash function is present — stash takes ownership by re-queuing.
   - Add ctx.Err() == nil guard to the UDP retransmit loop.
