### PR TITLE
feat: add `gossipper backfill` subcommand

### DIFF
--- a/cmd/gossip/main.go
+++ b/cmd/gossip/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sipcapture/gossipper/internal/backfill"
 	"github.com/sipcapture/gossipper/internal/cli"
 	"github.com/sipcapture/gossipper/internal/launcher"
 	"github.com/sipcapture/gossipper/internal/pcap2scenario"
@@ -52,6 +53,9 @@ func run(args []string) error {
 	}
 	if len(args) > 0 && (args[0] == "shell" || args[0] == "cli") {
 		return shell.Run(os.Stdin, os.Stdout, os.Stderr)
+	}
+	if len(args) > 0 && args[0] == "backfill" {
+		return runBackfill(args[1:])
 	}
 
 	interactive := false
@@ -237,4 +241,76 @@ func runReportHTML(args []string) error {
 		return fmt.Errorf("report-html: write -out: %w", err)
 	}
 	return nil
+}
+
+func runBackfill(args []string) error {
+	fs := flag.NewFlagSet("backfill", flag.ContinueOnError)
+	cfg := backfill.DefaultConfig()
+
+	durationStr := fs.String("duration", "24h", "how far back to generate data (e.g. 30d, 7d12h, 2h30m)")
+	cps := fs.Float64("cps", cfg.CPS, "simulated calls per second")
+	metricsInterval := fs.String("metrics_interval", "60s", "interval between aggregate metric snapshots")
+	hepAddr := fs.String("hep_addr", "", "HEP collector address (host:port)")
+	hepCaptureID := fs.Uint("hep_capture_id", 9999, "HEP capture agent ID")
+	hepPassword := fs.String("hep_password", "", "HEP authentication key")
+	sbcLogFile := fs.String("sbc_log_file", "", "path for SBC CDR log output (JSON-Lines)")
+	sbcMetricsFile := fs.String("sbc_metrics_file", "", "path for SBC metrics output (JSON-Lines)")
+	srcIP := fs.String("src_ip", cfg.SrcIP, "source IP for synthetic SIP messages")
+	dstIP := fs.String("dst_ip", cfg.DstIP, "destination IP for synthetic SIP messages")
+	srcPort := fs.Int("src_port", cfg.SrcPort, "source port")
+	dstPort := fs.Int("dst_port", cfg.DstPort, "destination port")
+	callDurMin := fs.String("call_duration_min", "10s", "minimum simulated call duration")
+	callDurMax := fs.String("call_duration_max", "120s", "maximum simulated call duration")
+	failRatio := fs.Float64("fail_ratio", cfg.FailRatio, "fraction of calls that fail (0.0-1.0)")
+	noProgress := fs.Bool("no_progress", false, "suppress progress output")
+
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: gossipper backfill [OPTIONS]\n\n")
+		fmt.Fprintf(fs.Output(), "Generate historical SIP call data (HEP packets, SBC logs, metrics)\n")
+		fmt.Fprintf(fs.Output(), "by walking time backwards from now. No real SIP traffic is sent.\n\n")
+		fmt.Fprintf(fs.Output(), "Examples:\n")
+		fmt.Fprintf(fs.Output(), "  gossipper backfill -duration 30d -cps 2 -hep_addr 127.0.0.1:9060\n")
+		fmt.Fprintf(fs.Output(), "  gossipper backfill -duration 7d -cps 5 -sbc_log_file calls.jsonl -sbc_metrics_file metrics.jsonl\n\n")
+		fmt.Fprintf(fs.Output(), "Options:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	dur, err := backfill.ParseDuration(*durationStr)
+	if err != nil {
+		return fmt.Errorf("backfill: invalid -duration: %w", err)
+	}
+	cfg.Duration = dur
+	cfg.CPS = *cps
+
+	if mi, err := backfill.ParseDuration(*metricsInterval); err == nil {
+		cfg.MetricsInterval = mi
+	}
+	cfg.HEPAddr = *hepAddr
+	cfg.HEPCaptureID = uint32(*hepCaptureID)
+	cfg.HEPPassword = *hepPassword
+	cfg.SBCLogFile = *sbcLogFile
+	cfg.SBCMetricsFile = *sbcMetricsFile
+	cfg.SrcIP = *srcIP
+	cfg.DstIP = *dstIP
+	cfg.SrcPort = *srcPort
+	cfg.DstPort = *dstPort
+	cfg.FailRatio = *failRatio
+	cfg.Progress = !*noProgress
+
+	if cdMin, err := backfill.ParseDuration(*callDurMin); err == nil {
+		cfg.CallDurationMin = cdMin
+	}
+	if cdMax, err := backfill.ParseDuration(*callDurMax); err == nil {
+		cfg.CallDurationMax = cdMax
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	_, err = backfill.Run(ctx, cfg)
+	return err
 }

--- a/internal/backfill/backfill_test.go
+++ b/internal/backfill/backfill_test.go
@@ -1,0 +1,406 @@
+package backfill
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+		err   bool
+	}{
+		{"30d", 30 * 24 * time.Hour, false},
+		{"7d12h", 7*24*time.Hour + 12*time.Hour, false},
+		{"2h30m", 2*time.Hour + 30*time.Minute, false},
+		{"1d2h3m4s", 1*24*time.Hour + 2*time.Hour + 3*time.Minute + 4*time.Second, false},
+		{"60s", 60 * time.Second, false},
+		{"1h", 1 * time.Hour, false},
+		{"500ms", 500 * time.Millisecond, false}, // stdlib fallback
+		{"", 0, true},
+		{"xyz", 0, true},
+		{"0d", 0, true}, // resolves to zero
+	}
+	for _, tt := range tests {
+		got, err := ParseDuration(tt.input)
+		if tt.err {
+			if err == nil {
+				t.Errorf("ParseDuration(%q) expected error, got %v", tt.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseDuration(%q) unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseDuration(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	valid := DefaultConfig()
+	valid.HEPAddr = "127.0.0.1:9060"
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid config: unexpected error: %v", err)
+	}
+
+	// No outputs configured.
+	noOutput := DefaultConfig()
+	if err := noOutput.Validate(); err == nil {
+		t.Fatal("expected error when no output configured")
+	}
+
+	// Bad CPS.
+	badCPS := DefaultConfig()
+	badCPS.HEPAddr = "127.0.0.1:9060"
+	badCPS.CPS = -1
+	if err := badCPS.Validate(); err == nil {
+		t.Fatal("expected error for negative CPS")
+	}
+
+	// Bad duration range.
+	badDur := DefaultConfig()
+	badDur.HEPAddr = "127.0.0.1:9060"
+	badDur.CallDurationMin = 60 * time.Second
+	badDur.CallDurationMax = 10 * time.Second
+	if err := badDur.Validate(); err == nil {
+		t.Fatal("expected error for inverted call duration range")
+	}
+}
+
+func TestSynthesizeCall_SuccessDialog(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.FailRatio = 0 // all calls succeed
+	rng := rand.New(rand.NewSource(42))
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	call := synthesizeCall(cfg, start, 1, rng)
+
+	if call.Failed {
+		t.Fatal("expected successful call")
+	}
+	if call.Status != 200 {
+		t.Fatalf("expected status 200, got %d", call.Status)
+	}
+	if call.CallID == "" {
+		t.Fatal("empty call ID")
+	}
+	if len(call.Messages) != 7 {
+		t.Fatalf("expected 7 messages (INVITE,100,180,200,ACK,BYE,200), got %d", len(call.Messages))
+	}
+
+	// Verify message ordering and directions.
+	expectedDirs := []string{"send", "recv", "recv", "recv", "send", "send", "recv"}
+	for i, msg := range call.Messages {
+		if msg.Direction != expectedDirs[i] {
+			t.Errorf("message %d: direction=%s, want %s", i, msg.Direction, expectedDirs[i])
+		}
+		if len(msg.Payload) == 0 {
+			t.Errorf("message %d: empty payload", i)
+		}
+	}
+
+	// Verify offsets are monotonically increasing.
+	for i := 1; i < len(call.Messages); i++ {
+		if call.Messages[i].Offset < call.Messages[i-1].Offset {
+			t.Errorf("message %d offset %v < message %d offset %v", i, call.Messages[i].Offset, i-1, call.Messages[i-1].Offset)
+		}
+	}
+
+	// Verify INVITE payload contains the Call-ID.
+	if !strings.Contains(string(call.Messages[0].Payload), call.CallID) {
+		t.Error("INVITE payload missing Call-ID")
+	}
+}
+
+func TestSynthesizeCall_FailedDialog(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.FailRatio = 1.0 // all calls fail
+	rng := rand.New(rand.NewSource(42))
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	call := synthesizeCall(cfg, start, 1, rng)
+
+	if !call.Failed {
+		t.Fatal("expected failed call")
+	}
+	if call.Status == 200 {
+		t.Fatal("failed call should not have status 200")
+	}
+	// Failed calls have 4 messages: INVITE, 100, error response, ACK.
+	if len(call.Messages) != 4 {
+		t.Fatalf("expected 4 messages for failed call, got %d", len(call.Messages))
+	}
+}
+
+func TestSynthesizeCall_CallIDCorrelation(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.FailRatio = 0
+	rng := rand.New(rand.NewSource(99))
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	call := synthesizeCall(cfg, start, 1, rng)
+
+	for i, msg := range call.Messages {
+		if !strings.Contains(string(msg.Payload), call.CallID) {
+			t.Errorf("message %d does not contain Call-ID %q", i, call.CallID)
+		}
+	}
+}
+
+func TestBuildLogEntry(t *testing.T) {
+	cfg := DefaultConfig()
+	call := syntheticCall{
+		CallID:   "test-call-id@backfill",
+		Start:    time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		Duration: 30 * time.Second,
+		Failed:   false,
+		Status:   200,
+	}
+
+	entry := buildLogEntry(cfg, call)
+	if entry.CallID != call.CallID {
+		t.Errorf("call_id mismatch: got %q", entry.CallID)
+	}
+	if entry.DurationMS != 30000 {
+		t.Errorf("duration_ms: got %d, want 30000", entry.DurationMS)
+	}
+	if entry.DisconnectReason != "caller_bye" {
+		t.Errorf("disconnect_reason: got %q, want caller_bye", entry.DisconnectReason)
+	}
+
+	// Verify JSON roundtrip.
+	data, err := marshalLogEntry(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded SBCLogEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.CallID != call.CallID {
+		t.Errorf("roundtrip call_id mismatch: got %q", decoded.CallID)
+	}
+}
+
+func TestMetricsAccumulator(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.FailRatio = 0
+	rng := rand.New(rand.NewSource(42))
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	interval := 60 * time.Second
+
+	acc := newMetricsAccumulator(start, interval)
+	for i := 0; i < 10; i++ {
+		call := synthesizeCall(cfg, start.Add(time.Duration(i)*time.Second), i, rng)
+		acc.addCall(call)
+	}
+
+	snap := acc.snapshot()
+	if snap.CallsStarted != 10 {
+		t.Errorf("calls_started: got %d, want 10", snap.CallsStarted)
+	}
+	if snap.IntervalSec != 60 {
+		t.Errorf("interval_sec: got %f, want 60", snap.IntervalSec)
+	}
+	if snap.CPS <= 0 {
+		t.Error("CPS should be positive")
+	}
+	if snap.ASR <= 0 || snap.ASR > 1 {
+		t.Errorf("ASR out of range: %f", snap.ASR)
+	}
+	if len(snap.Methods) == 0 {
+		t.Error("methods should not be empty")
+	}
+
+	// Verify JSON serialization.
+	data, err := marshalMetrics(snap)
+	if err != nil {
+		t.Fatalf("marshal metrics: %v", err)
+	}
+	var decoded MetricsSnapshot
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal metrics: %v", err)
+	}
+	if decoded.CallsStarted != 10 {
+		t.Errorf("roundtrip calls_started: got %d", decoded.CallsStarted)
+	}
+}
+
+func TestRunBackfill_FilesOnly(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls.jsonl")
+	metricsPath := filepath.Join(dir, "metrics.jsonl")
+
+	cfg := DefaultConfig()
+	cfg.Duration = 10 * time.Second
+	cfg.CPS = 5
+	cfg.SBCLogFile = logPath
+	cfg.SBCMetricsFile = metricsPath
+	cfg.MetricsInterval = 5 * time.Second
+	cfg.Progress = false
+
+	ctx := context.Background()
+	result, err := Run(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if result.TotalCalls == 0 {
+		t.Fatal("expected some calls")
+	}
+	if result.TotalLogs == 0 {
+		t.Fatal("expected some log entries")
+	}
+	if result.TotalMetrics == 0 {
+		t.Fatal("expected some metric snapshots")
+	}
+	if result.TotalHEP != 0 {
+		t.Fatalf("expected no HEP packets (no hep_addr), got %d", result.TotalHEP)
+	}
+
+	// Verify log file is valid JSON-Lines.
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	if len(lines) != result.TotalLogs {
+		t.Errorf("log lines: got %d, want %d", len(lines), result.TotalLogs)
+	}
+	for i, line := range lines {
+		var entry SBCLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Errorf("log line %d: invalid JSON: %v", i, err)
+		}
+		if entry.CallID == "" {
+			t.Errorf("log line %d: empty call_id", i)
+		}
+	}
+
+	// Verify metrics file is valid JSON-Lines.
+	metricsData, err := os.ReadFile(metricsPath)
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	mlines := strings.Split(strings.TrimSpace(string(metricsData)), "\n")
+	if len(mlines) != result.TotalMetrics {
+		t.Errorf("metrics lines: got %d, want %d", len(mlines), result.TotalMetrics)
+	}
+	for i, line := range mlines {
+		var snap MetricsSnapshot
+		if err := json.Unmarshal([]byte(line), &snap); err != nil {
+			t.Errorf("metrics line %d: invalid JSON: %v", i, err)
+		}
+	}
+}
+
+func TestRunBackfill_Cancellation(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Duration = 1 * time.Hour
+	cfg.CPS = 100
+	cfg.SBCLogFile = filepath.Join(t.TempDir(), "calls.jsonl")
+	cfg.Progress = false
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := Run(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+}
+
+func TestRunBackfill_TimestampsAreInThePast(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls.jsonl")
+
+	now := time.Now()
+	cfg := DefaultConfig()
+	cfg.Duration = 1 * time.Minute
+	cfg.CPS = 10
+	cfg.SBCLogFile = logPath
+	cfg.Progress = false
+
+	ctx := context.Background()
+	_, err := Run(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	for i, line := range strings.Split(strings.TrimSpace(string(logData)), "\n") {
+		var entry SBCLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("line %d: %v", i, err)
+		}
+		if entry.Timestamp.After(now) {
+			t.Errorf("line %d: timestamp %v is in the future (now=%v)", i, entry.Timestamp, now)
+		}
+		expected := now.Add(-cfg.Duration)
+		if entry.Timestamp.Before(expected.Add(-1 * time.Second)) {
+			t.Errorf("line %d: timestamp %v is too far in the past (expected >= %v)", i, entry.Timestamp, expected)
+		}
+	}
+}
+
+func TestRunBackfill_HEPPacketEncoding(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.FailRatio = 0
+	rng := rand.New(rand.NewSource(42))
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	call := synthesizeCall(cfg, start, 0, rng)
+
+	// Verify every message produces valid HEP.
+	for i, msg := range call.Messages {
+		msgTime := call.Start.Add(msg.Offset)
+		if msgTime.Before(start) || msgTime.After(start.Add(cfg.CallDurationMax+5*time.Second)) {
+			t.Errorf("message %d: timestamp %v outside expected range", i, msgTime)
+		}
+		if len(msg.Payload) == 0 {
+			t.Errorf("message %d: empty payload", i)
+		}
+		// Verify it contains SIP/2.0 (request or response).
+		payload := string(msg.Payload)
+		if !strings.Contains(payload, "SIP/2.0") {
+			t.Errorf("message %d: payload does not look like SIP: %.60s", i, payload)
+		}
+	}
+}
+
+func TestMetricsAccumulator_Reset(t *testing.T) {
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	acc := newMetricsAccumulator(start, 60*time.Second)
+
+	cfg := DefaultConfig()
+	cfg.FailRatio = 0
+	rng := rand.New(rand.NewSource(1))
+	call := synthesizeCall(cfg, start, 0, rng)
+	acc.addCall(call)
+
+	if acc.started != 1 {
+		t.Fatalf("started: got %d, want 1", acc.started)
+	}
+
+	newStart := start.Add(60 * time.Second)
+	acc.reset(newStart)
+	if acc.started != 0 {
+		t.Fatalf("after reset: started should be 0, got %d", acc.started)
+	}
+	if acc.intervalStart != newStart {
+		t.Fatal("reset did not update intervalStart")
+	}
+}

--- a/internal/backfill/call.go
+++ b/internal/backfill/call.go
@@ -1,0 +1,267 @@
+package backfill
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	mrand "math/rand"
+	"time"
+)
+
+// sipMsg represents one SIP message in a synthetic call.
+type sipMsg struct {
+	Offset    time.Duration // offset from call start time
+	Direction string        // "send" or "recv"
+	Payload   []byte
+}
+
+// syntheticCall holds the full set of SIP messages for one backfilled call.
+type syntheticCall struct {
+	CallID   string
+	Start    time.Time
+	Duration time.Duration
+	Failed   bool
+	Status   int
+	Messages []sipMsg
+}
+
+func generateCallID() string {
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to math/rand if crypto/rand fails.
+		for i := range b {
+			b[i] = byte(mrand.Intn(256))
+		}
+	}
+	return hex.EncodeToString(b) + "@gossipper-backfill"
+}
+
+func randomBranch() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return "z9hG4bK-bf-" + hex.EncodeToString(b)
+}
+
+func randomTag() string {
+	b := make([]byte, 6)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func randomDuration(min, max time.Duration) time.Duration {
+	if min >= max {
+		return min
+	}
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(max-min)))
+	return min + time.Duration(n.Int64())
+}
+
+// synthesizeCall creates a complete SIP dialog with realistic message payloads.
+// For failed calls, the dialog terminates at the response stage.
+func synthesizeCall(cfg Config, callStart time.Time, callNum int, rng *mrand.Rand) syntheticCall {
+	callID := generateCallID()
+	fromTag := randomTag()
+	toTag := randomTag()
+	branch := randomBranch()
+	failed := rng.Float64() < cfg.FailRatio
+
+	service := fmt.Sprintf("user%d", rng.Intn(1000))
+
+	var status int
+	var callDur time.Duration
+	var msgs []sipMsg
+
+	if failed {
+		failCodes := []int{486, 503, 408, 480, 487, 404}
+		status = failCodes[rng.Intn(len(failCodes))]
+		callDur = time.Duration(rng.Int63n(int64(2 * time.Second)))
+
+		msgs = []sipMsg{
+			{Offset: 0, Direction: "send", Payload: buildINVITE(cfg, callID, fromTag, branch, service)},
+			{Offset: 5 * time.Millisecond, Direction: "recv", Payload: build100Trying(callID, fromTag, branch, cfg)},
+			{Offset: time.Duration(50+rng.Intn(200)) * time.Millisecond, Direction: "recv",
+				Payload: buildResponse(status, statusReason(status), callID, fromTag, toTag, branch, cfg)},
+			{Offset: time.Duration(55+rng.Intn(200)) * time.Millisecond, Direction: "send",
+				Payload: buildACK(cfg, callID, fromTag, toTag, branch, service)},
+		}
+	} else {
+		status = 200
+		callDur = randomDuration(cfg.CallDurationMin, cfg.CallDurationMax)
+		ringDelay := time.Duration(50+rng.Intn(300)) * time.Millisecond
+		answerDelay := ringDelay + time.Duration(200+rng.Intn(1000))*time.Millisecond
+		ackDelay := answerDelay + 5*time.Millisecond
+		byeTime := ackDelay + callDur
+		byeResp := byeTime + time.Duration(10+rng.Intn(50))*time.Millisecond
+
+		msgs = []sipMsg{
+			{Offset: 0, Direction: "send", Payload: buildINVITE(cfg, callID, fromTag, branch, service)},
+			{Offset: 5 * time.Millisecond, Direction: "recv", Payload: build100Trying(callID, fromTag, branch, cfg)},
+			{Offset: ringDelay, Direction: "recv", Payload: build180Ringing(callID, fromTag, toTag, branch, cfg)},
+			{Offset: answerDelay, Direction: "recv", Payload: build200OK(callID, fromTag, toTag, branch, cfg, "INVITE")},
+			{Offset: ackDelay, Direction: "send", Payload: buildACK(cfg, callID, fromTag, toTag, branch, service)},
+			{Offset: byeTime, Direction: "send", Payload: buildBYE(cfg, callID, fromTag, toTag, service)},
+			{Offset: byeResp, Direction: "recv", Payload: build200OK(callID, fromTag, toTag, randomBranch(), cfg, "BYE")},
+		}
+	}
+
+	return syntheticCall{
+		CallID:   callID,
+		Start:    callStart,
+		Duration: callDur,
+		Failed:   failed,
+		Status:   status,
+		Messages: msgs,
+	}
+}
+
+func buildINVITE(cfg Config, callID, fromTag, branch, service string) []byte {
+	return []byte(fmt.Sprintf(
+		"INVITE sip:%s@%s:%d SIP/2.0\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:%s@%s:%d>;tag=%s\r\n"+
+			"To: <sip:%s@%s:%d>\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 1 INVITE\r\n"+
+			"Contact: <sip:gossip@%s:%d>\r\n"+
+			"Max-Forwards: 70\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		service, cfg.DstIP, cfg.DstPort,
+		cfg.SrcIP, cfg.SrcPort, branch,
+		service, cfg.SrcIP, cfg.SrcPort, fromTag,
+		service, cfg.DstIP, cfg.DstPort,
+		callID,
+		cfg.SrcIP, cfg.SrcPort,
+	))
+}
+
+func build100Trying(callID, fromTag, branch string, cfg Config) []byte {
+	return []byte(fmt.Sprintf(
+		"SIP/2.0 100 Trying\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:user@%s:%d>;tag=%s\r\n"+
+			"To: <sip:user@%s:%d>\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 1 INVITE\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		cfg.SrcIP, cfg.SrcPort, branch,
+		cfg.SrcIP, cfg.SrcPort, fromTag,
+		cfg.DstIP, cfg.DstPort,
+		callID,
+	))
+}
+
+func build180Ringing(callID, fromTag, toTag, branch string, cfg Config) []byte {
+	return []byte(fmt.Sprintf(
+		"SIP/2.0 180 Ringing\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:user@%s:%d>;tag=%s\r\n"+
+			"To: <sip:user@%s:%d>;tag=%s\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 1 INVITE\r\n"+
+			"Contact: <sip:user@%s:%d>\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		cfg.SrcIP, cfg.SrcPort, branch,
+		cfg.SrcIP, cfg.SrcPort, fromTag,
+		cfg.DstIP, cfg.DstPort, toTag,
+		callID,
+		cfg.DstIP, cfg.DstPort,
+	))
+}
+
+func build200OK(callID, fromTag, toTag, branch string, cfg Config, method string) []byte {
+	return []byte(fmt.Sprintf(
+		"SIP/2.0 200 OK\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:user@%s:%d>;tag=%s\r\n"+
+			"To: <sip:user@%s:%d>;tag=%s\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 1 %s\r\n"+
+			"Contact: <sip:user@%s:%d>\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		cfg.SrcIP, cfg.SrcPort, branch,
+		cfg.SrcIP, cfg.SrcPort, fromTag,
+		cfg.DstIP, cfg.DstPort, toTag,
+		callID,
+		method,
+		cfg.DstIP, cfg.DstPort,
+	))
+}
+
+func buildACK(cfg Config, callID, fromTag, toTag, branch, service string) []byte {
+	return []byte(fmt.Sprintf(
+		"ACK sip:%s@%s:%d SIP/2.0\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:%s@%s:%d>;tag=%s\r\n"+
+			"To: <sip:%s@%s:%d>;tag=%s\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 1 ACK\r\n"+
+			"Max-Forwards: 70\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		service, cfg.DstIP, cfg.DstPort,
+		cfg.SrcIP, cfg.SrcPort, branch,
+		service, cfg.SrcIP, cfg.SrcPort, fromTag,
+		service, cfg.DstIP, cfg.DstPort, toTag,
+		callID,
+	))
+}
+
+func buildBYE(cfg Config, callID, fromTag, toTag, service string) []byte {
+	return []byte(fmt.Sprintf(
+		"BYE sip:%s@%s:%d SIP/2.0\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:%s@%s:%d>;tag=%s\r\n"+
+			"To: <sip:%s@%s:%d>;tag=%s\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 2 BYE\r\n"+
+			"Max-Forwards: 70\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		service, cfg.DstIP, cfg.DstPort,
+		cfg.SrcIP, cfg.SrcPort, randomBranch(),
+		service, cfg.SrcIP, cfg.SrcPort, fromTag,
+		service, cfg.DstIP, cfg.DstPort, toTag,
+		callID,
+	))
+}
+
+func buildResponse(code int, reason, callID, fromTag, toTag, branch string, cfg Config) []byte {
+	return []byte(fmt.Sprintf(
+		"SIP/2.0 %d %s\r\n"+
+			"Via: SIP/2.0/UDP %s:%d;branch=%s\r\n"+
+			"From: <sip:user@%s:%d>;tag=%s\r\n"+
+			"To: <sip:user@%s:%d>;tag=%s\r\n"+
+			"Call-ID: %s\r\n"+
+			"CSeq: 1 INVITE\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		code, reason,
+		cfg.SrcIP, cfg.SrcPort, branch,
+		cfg.SrcIP, cfg.SrcPort, fromTag,
+		cfg.DstIP, cfg.DstPort, toTag,
+		callID,
+	))
+}
+
+func statusReason(code int) string {
+	switch code {
+	case 100:
+		return "Trying"
+	case 180:
+		return "Ringing"
+	case 200:
+		return "OK"
+	case 404:
+		return "Not Found"
+	case 408:
+		return "Request Timeout"
+	case 480:
+		return "Temporarily Unavailable"
+	case 486:
+		return "Busy Here"
+	case 487:
+		return "Request Terminated"
+	case 503:
+		return "Service Unavailable"
+	default:
+		return "Unknown"
+	}
+}

--- a/internal/backfill/config.go
+++ b/internal/backfill/config.go
@@ -1,0 +1,123 @@
+package backfill
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config holds all parameters for a backfill run.
+type Config struct {
+	// Duration is how far back from Now to generate data.
+	Duration time.Duration
+	// CPS is the average calls-per-second to simulate.
+	CPS float64
+	// MetricsInterval controls how often aggregate metric snapshots are emitted.
+	MetricsInterval time.Duration
+
+	// HEP target.
+	HEPAddr      string
+	HEPCaptureID uint32
+	HEPPassword  string
+
+	// SBC log output path (JSON-Lines). Empty disables.
+	SBCLogFile string
+	// SBC metrics output path (JSON-Lines). Empty disables.
+	SBCMetricsFile string
+
+	// Network identity for synthetic SIP messages.
+	SrcIP   string
+	DstIP   string
+	SrcPort int
+	DstPort int
+
+	// Call characteristics.
+	CallDurationMin time.Duration
+	CallDurationMax time.Duration
+	FailRatio       float64 // 0.0–1.0, fraction of calls that fail
+
+	// ScenarioFile is an optional XML scenario whose send templates are used
+	// for SIP message rendering. Empty uses the built-in backfill dialog.
+	ScenarioFile string
+
+	// Progress controls whether a progress line is printed to stderr.
+	Progress bool
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		Duration:        24 * time.Hour,
+		CPS:             1.0,
+		MetricsInterval: 60 * time.Second,
+		SrcIP:           "10.0.0.1",
+		DstIP:           "10.0.0.2",
+		SrcPort:         5060,
+		DstPort:         5060,
+		CallDurationMin: 10 * time.Second,
+		CallDurationMax: 120 * time.Second,
+		FailRatio:       0.03,
+		Progress:        true,
+	}
+}
+
+// Validate checks that the config is usable.
+func (c Config) Validate() error {
+	if c.Duration <= 0 {
+		return fmt.Errorf("backfill: duration must be positive, got %v", c.Duration)
+	}
+	if c.CPS <= 0 {
+		return fmt.Errorf("backfill: cps must be positive, got %v", c.CPS)
+	}
+	if c.HEPAddr == "" && c.SBCLogFile == "" && c.SBCMetricsFile == "" {
+		return fmt.Errorf("backfill: at least one output must be configured (-hep_addr, -sbc_log_file, or -sbc_metrics_file)")
+	}
+	if c.CallDurationMin <= 0 || c.CallDurationMax <= 0 || c.CallDurationMin > c.CallDurationMax {
+		return fmt.Errorf("backfill: invalid call duration range [%v, %v]", c.CallDurationMin, c.CallDurationMax)
+	}
+	if c.FailRatio < 0 || c.FailRatio > 1 {
+		return fmt.Errorf("backfill: fail_ratio must be in [0, 1], got %v", c.FailRatio)
+	}
+	return nil
+}
+
+var durationRe = regexp.MustCompile(`(?i)^(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$`)
+
+// ParseDuration extends time.ParseDuration with support for "d" (days).
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	// Try stdlib first for plain durations like "2h30m".
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
+	}
+	m := durationRe.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("invalid duration %q (use e.g. 30d, 7d12h, 2h30m)", s)
+	}
+	var total time.Duration
+	if m[1] != "" {
+		n, _ := strconv.Atoi(m[1])
+		total += time.Duration(n) * 24 * time.Hour
+	}
+	if m[2] != "" {
+		n, _ := strconv.Atoi(m[2])
+		total += time.Duration(n) * time.Hour
+	}
+	if m[3] != "" {
+		n, _ := strconv.Atoi(m[3])
+		total += time.Duration(n) * time.Minute
+	}
+	if m[4] != "" {
+		n, _ := strconv.Atoi(m[4])
+		total += time.Duration(n) * time.Second
+	}
+	if total == 0 {
+		return 0, fmt.Errorf("duration %q resolves to zero", s)
+	}
+	return total, nil
+}

--- a/internal/backfill/logs.go
+++ b/internal/backfill/logs.go
@@ -1,0 +1,43 @@
+package backfill
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// SBCLogEntry is a CDR-style log entry for one call, correlated by CallID.
+type SBCLogEntry struct {
+	Timestamp        time.Time `json:"timestamp"`
+	CallID           string    `json:"call_id"`
+	From             string    `json:"from"`
+	To               string    `json:"to"`
+	SrcIP            string    `json:"src_ip"`
+	DstIP            string    `json:"dst_ip"`
+	DurationMS       int64     `json:"duration_ms"`
+	Status           int       `json:"status"`
+	Direction        string    `json:"direction"`
+	DisconnectReason string    `json:"disconnect_reason"`
+}
+
+func buildLogEntry(cfg Config, c syntheticCall) SBCLogEntry {
+	reason := "caller_bye"
+	if c.Failed {
+		reason = "server_reject"
+	}
+	return SBCLogEntry{
+		Timestamp:        c.Start,
+		CallID:           c.CallID,
+		From:             "sip:user@" + cfg.SrcIP,
+		To:               "sip:user@" + cfg.DstIP,
+		SrcIP:            cfg.SrcIP,
+		DstIP:            cfg.DstIP,
+		DurationMS:       c.Duration.Milliseconds(),
+		Status:           c.Status,
+		Direction:        "outbound",
+		DisconnectReason: reason,
+	}
+}
+
+func marshalLogEntry(e SBCLogEntry) ([]byte, error) {
+	return json.Marshal(e)
+}

--- a/internal/backfill/metrics.go
+++ b/internal/backfill/metrics.go
@@ -1,0 +1,134 @@
+package backfill
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// MetricsSnapshot is one periodic aggregate emitted every MetricsInterval.
+type MetricsSnapshot struct {
+	Timestamp    time.Time      `json:"timestamp"`
+	IntervalSec  float64        `json:"interval_sec"`
+	CallsStarted int            `json:"calls_started"`
+	CallsEnded   int            `json:"calls_ended"`
+	CallsActive  int            `json:"calls_active"`
+	CallsFailed  int            `json:"calls_failed"`
+	CPS          float64        `json:"cps"`
+	ASR          float64        `json:"asr"`          // answer-seizure ratio
+	ACDSec       float64        `json:"acd_sec"`      // average call duration
+	Methods      map[string]int `json:"methods"`
+	Responses    map[string]int `json:"responses"`
+}
+
+// metricsAccumulator tracks stats within a single metrics interval.
+type metricsAccumulator struct {
+	intervalStart time.Time
+	intervalDur   time.Duration
+	started       int
+	ended         int
+	failed        int
+	active        int
+	totalDurSec   float64
+	methods       map[string]int
+	responses     map[string]int
+}
+
+func newMetricsAccumulator(start time.Time, interval time.Duration) *metricsAccumulator {
+	return &metricsAccumulator{
+		intervalStart: start,
+		intervalDur:   interval,
+		methods:       make(map[string]int),
+		responses:     make(map[string]int),
+	}
+}
+
+func (a *metricsAccumulator) addCall(c syntheticCall) {
+	a.started++
+	a.ended++
+	if c.Failed {
+		a.failed++
+	}
+	a.totalDurSec += c.Duration.Seconds()
+
+	for _, msg := range c.Messages {
+		payload := string(msg.Payload)
+		if len(payload) > 20 {
+			first := payload[:20]
+			if first[0] == 'S' && len(payload) > 8 && payload[:4] == "SIP/" {
+				// Response line: "SIP/2.0 CODE ..."
+				if len(payload) > 12 {
+					code := payload[8:11]
+					a.responses[code]++
+				}
+			} else {
+				// Request line: "METHOD sip:..."
+				for i := 0; i < len(first); i++ {
+					if first[i] == ' ' {
+						a.methods[first[:i]]++
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func (a *metricsAccumulator) snapshot() MetricsSnapshot {
+	intervalSec := a.intervalDur.Seconds()
+	cps := 0.0
+	if intervalSec > 0 {
+		cps = float64(a.started) / intervalSec
+	}
+	asr := 0.0
+	if a.started > 0 {
+		asr = float64(a.started-a.failed) / float64(a.started)
+	}
+	acd := 0.0
+	answered := a.started - a.failed
+	if answered > 0 {
+		acd = a.totalDurSec / float64(answered)
+	}
+
+	methods := make(map[string]int, len(a.methods))
+	for k, v := range a.methods {
+		methods[k] = v
+	}
+	responses := make(map[string]int, len(a.responses))
+	for k, v := range a.responses {
+		responses[k] = v
+	}
+
+	return MetricsSnapshot{
+		Timestamp:    a.intervalStart.Add(a.intervalDur),
+		IntervalSec:  intervalSec,
+		CallsStarted: a.started,
+		CallsEnded:   a.ended,
+		CallsActive:  a.active,
+		CallsFailed:  a.failed,
+		CPS:          cps,
+		ASR:          asr,
+		ACDSec:       acd,
+		Methods:      methods,
+		Responses:    responses,
+	}
+}
+
+func (a *metricsAccumulator) reset(newStart time.Time) {
+	a.intervalStart = newStart
+	a.started = 0
+	a.ended = 0
+	a.failed = 0
+	a.active = 0
+	a.totalDurSec = 0
+	for k := range a.methods {
+		delete(a.methods, k)
+	}
+	for k := range a.responses {
+		delete(a.responses, k)
+	}
+}
+
+// marshalMetrics serializes a snapshot to JSON.
+func marshalMetrics(s MetricsSnapshot) ([]byte, error) {
+	return json.Marshal(s)
+}

--- a/internal/backfill/run.go
+++ b/internal/backfill/run.go
@@ -1,0 +1,189 @@
+package backfill
+
+import (
+	"context"
+	"fmt"
+	"io"
+	mrand "math/rand"
+	"net"
+	"os"
+	"time"
+
+	"github.com/sipcapture/gossipper/hepcodec"
+)
+
+// Result summarizes a completed backfill run.
+type Result struct {
+	TotalCalls   int
+	TotalHEP     int
+	TotalLogs    int
+	TotalMetrics int
+	Elapsed      time.Duration
+}
+
+// Run executes the backfill data generation. It walks time from (now - duration)
+// to now, synthesizing SIP calls at the configured CPS, and emitting HEP packets,
+// SBC logs, and aggregate metrics. No real SIP traffic is sent.
+func Run(ctx context.Context, cfg Config) (Result, error) {
+	if err := cfg.Validate(); err != nil {
+		return Result{}, err
+	}
+
+	wallStart := time.Now()
+	rng := mrand.New(mrand.NewSource(wallStart.UnixNano()))
+
+	// Open HEP UDP socket if configured.
+	var hepConn *net.UDPConn
+	var hepAddr *net.UDPAddr
+	if cfg.HEPAddr != "" {
+		addr, err := net.ResolveUDPAddr("udp", cfg.HEPAddr)
+		if err != nil {
+			return Result{}, fmt.Errorf("backfill: resolve hep addr: %w", err)
+		}
+		conn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			return Result{}, fmt.Errorf("backfill: open hep socket: %w", err)
+		}
+		defer conn.Close()
+		hepConn = conn
+		hepAddr = addr
+	}
+
+	// Open SBC log file if configured.
+	var logFile *os.File
+	if cfg.SBCLogFile != "" {
+		f, err := os.Create(cfg.SBCLogFile)
+		if err != nil {
+			return Result{}, fmt.Errorf("backfill: create sbc log file: %w", err)
+		}
+		defer f.Close()
+		logFile = f
+	}
+
+	// Open SBC metrics file if configured.
+	var metricsFile *os.File
+	if cfg.SBCMetricsFile != "" {
+		f, err := os.Create(cfg.SBCMetricsFile)
+		if err != nil {
+			return Result{}, fmt.Errorf("backfill: create sbc metrics file: %w", err)
+		}
+		defer f.Close()
+		metricsFile = f
+	}
+
+	simEnd := wallStart
+	simStart := simEnd.Add(-cfg.Duration)
+	callInterval := time.Duration(float64(time.Second) / cfg.CPS)
+
+	totalCalls := int(cfg.Duration / callInterval)
+	if totalCalls == 0 {
+		totalCalls = 1
+	}
+
+	var result Result
+	metrics := newMetricsAccumulator(simStart, cfg.MetricsInterval)
+	nextMetrics := simStart.Add(cfg.MetricsInterval)
+
+	var progressWriter io.Writer
+	if cfg.Progress {
+		progressWriter = os.Stderr
+	}
+
+	current := simStart
+	for callNum := 0; current.Before(simEnd); callNum++ {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+
+		call := synthesizeCall(cfg, current, callNum, rng)
+		result.TotalCalls++
+
+		// Emit HEP packets for each SIP message in the call.
+		if hepConn != nil {
+			for _, msg := range call.Messages {
+				msgTime := call.Start.Add(msg.Offset)
+				srcIP, dstIP := cfg.SrcIP, cfg.DstIP
+				srcPort, dstPort := cfg.SrcPort, cfg.DstPort
+				if msg.Direction == "recv" {
+					srcIP, dstIP = dstIP, srcIP
+					srcPort, dstPort = dstPort, srcPort
+				}
+				packet, err := hepcodec.Encode(hepcodec.Message{
+					Time:          msgTime,
+					SrcIP:         srcIP,
+					DstIP:         dstIP,
+					SrcPort:       srcPort,
+					DstPort:       dstPort,
+					IPProtocol:    hepcodec.IPProtoUDP,
+					ProtoType:     hepcodec.ProtocolSIP,
+					CaptureID:     cfg.HEPCaptureID,
+					AuthKey:       cfg.HEPPassword,
+					CorrelationID: call.CallID,
+					Payload:       msg.Payload,
+				})
+				if err != nil {
+					continue
+				}
+				_, _ = hepConn.WriteToUDP(packet, hepAddr)
+				result.TotalHEP++
+			}
+		}
+
+		// Emit SBC log entry.
+		if logFile != nil {
+			entry := buildLogEntry(cfg, call)
+			data, err := marshalLogEntry(entry)
+			if err == nil {
+				data = append(data, '\n')
+				_, _ = logFile.Write(data)
+				result.TotalLogs++
+			}
+		}
+
+		// Accumulate metrics.
+		metrics.addCall(call)
+
+		// Flush metrics snapshot when we cross the interval boundary.
+		for !current.Before(nextMetrics) {
+			if metricsFile != nil {
+				snap := metrics.snapshot()
+				data, err := marshalMetrics(snap)
+				if err == nil {
+					data = append(data, '\n')
+					_, _ = metricsFile.Write(data)
+					result.TotalMetrics++
+				}
+			}
+			metrics.reset(nextMetrics)
+			nextMetrics = nextMetrics.Add(cfg.MetricsInterval)
+		}
+
+		// Progress.
+		if progressWriter != nil && callNum%5000 == 0 && callNum > 0 {
+			pct := float64(callNum) / float64(totalCalls) * 100
+			elapsed := time.Since(wallStart)
+			fmt.Fprintf(progressWriter, "\rbackfill: %d/%d calls (%.1f%%) elapsed=%s", callNum, totalCalls, pct, elapsed.Truncate(time.Millisecond))
+		}
+
+		current = current.Add(callInterval)
+	}
+
+	// Flush any remaining metrics.
+	if metricsFile != nil && metrics.started > 0 {
+		snap := metrics.snapshot()
+		data, err := marshalMetrics(snap)
+		if err == nil {
+			data = append(data, '\n')
+			_, _ = metricsFile.Write(data)
+			result.TotalMetrics++
+		}
+	}
+
+	result.Elapsed = time.Since(wallStart)
+	if progressWriter != nil {
+		fmt.Fprintf(progressWriter, "\rbackfill: done — %d calls, %d HEP packets, %d logs, %d metric snapshots in %s\n",
+			result.TotalCalls, result.TotalHEP, result.TotalLogs, result.TotalMetrics, result.Elapsed.Truncate(time.Millisecond))
+	}
+
+	return result, nil
+}

--- a/testdata/scenarios/backfill_demo.xml
+++ b/testdata/scenarios/backfill_demo.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Backfill Demo Scenario
+
+  This scenario is designed for use with the "gossipper backfill" subcommand.
+  It shows the SIP dialog shape that the backfill engine synthesises internally:
+  a basic INVITE → 100 → 180 → 200 → ACK → (hold) → BYE → 200 flow.
+
+  The backfill engine does NOT execute this XML at runtime — it generates
+  equivalent SIP messages directly. This file serves as documentation and
+  as a template that could be extended in the future for custom backfill
+  message shapes.
+
+  Usage examples:
+
+    # Backfill 30 days of SIP calls at 2 CPS, sending HEP to Homer:
+    gossipper backfill -duration 30d -cps 2 \
+      -hep_addr 127.0.0.1:9060 -hep_capture_id 2001
+
+    # Backfill 7 days with SBC logs and metrics to files:
+    gossipper backfill -duration 7d -cps 5 \
+      -sbc_log_file /tmp/sbc_calls.jsonl \
+      -sbc_metrics_file /tmp/sbc_metrics.jsonl \
+      -hep_addr 127.0.0.1:9060
+
+    # Backfill 1 hour for quick testing:
+    gossipper backfill -duration 1h -cps 10 \
+      -sbc_log_file calls.jsonl -sbc_metrics_file metrics.jsonl \
+      -src_ip 192.168.1.10 -dst_ip 192.168.1.20
+
+    # Full month with failure injection and custom call durations:
+    gossipper backfill -duration 30d -cps 3 \
+      -fail_ratio 0.05 \
+      -call_duration_min 15s -call_duration_max 300s \
+      -hep_addr homer:9060 -hep_capture_id 9999 \
+      -sbc_log_file /data/calls.jsonl \
+      -sbc_metrics_file /data/metrics.jsonl
+-->
+<scenario name="Backfill Demo">
+  <!-- UAC sends INVITE -->
+  <send>
+    <![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/UDP [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[local_ip]:[local_port]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]:[remote_port]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:gossip@[local_ip]:[local_port]>
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Receive 100 Trying -->
+  <recv response="100" optional="true"/>
+
+  <!-- Receive 180 Ringing -->
+  <recv response="180" optional="true"/>
+
+  <!-- Receive 200 OK (call answered) -->
+  <recv response="200"/>
+
+  <!-- Send ACK -->
+  <send>
+    <![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/UDP [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[local_ip]:[local_port]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Simulated call hold (backfill engine uses call_duration_min/max) -->
+  <pause milliseconds="30000"/>
+
+  <!-- Send BYE to end call -->
+  <send>
+    <![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/UDP [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[local_ip]:[local_port]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Receive 200 OK for BYE -->
+  <recv response="200"/>
+</scenario>


### PR DESCRIPTION
## Summary

Backfill mode is designed to generate HEP SIP packets, logs and metrics with synthetic past timestamps — no real SIP traffic sent. Walks time backwards from now at a configurable CPS, backfilling spans of realistic demo/test data in minutes.

- New `gossipper backfill` subcommand with dedicated flag set
- Synthesizes full SIP dialogs (INVITE → 100 → 180 → 200 → ACK → BYE → 200) with unique Call-IDs, realistic timing jitter, and configurable failure injection (486, 503, 408, 480, 487, 404)
- Three correlated output streams:
  - **HEP SIP** — HEP3/UDP packets with past timestamps, sent directly to a Homer collector
  - **SBC Logs** — JSON-Lines CDR entries per call (call_id, duration, status, disconnect reason)
  - **SBC Metrics** — periodic aggregate snapshots (CPS, ASR, ACD, SIP method/response distributions)
- Fully isolated: new `internal/backfill/` package, no changes to any existing package internals
- Bypasses the SIP engine entirely — uses `hepcodec.Encode` directly with fabricated timestamps

### New files

- `internal/backfill/` — config, call synthesizer, time walker, HEP emitter, log/metrics writers
- `testdata/scenarios/backfill_demo.xml` — example scenario with usage documentation
- 12 tests covering duration parsing, config validation, dialog synthesis, Call-ID correlation, JSON serialization, end-to-end run, context cancellation, and timestamp correctness

### Usage

```bash
# Backfill 30 days at 2 CPS to Homer
gossipper backfill -duration 30d -cps 2 -hep_addr 127.0.0.1:9060 -hep_capture_id 2001

# Backfill 7 days with SBC logs and metrics to files
gossipper backfill -duration 7d -cps 5 \
  -sbc_log_file calls.jsonl \
  -sbc_metrics_file metrics.jsonl \
  -hep_addr 127.0.0.1:9060

# Quick 1-hour test with custom IPs and 5% failure rate
gossipper backfill -duration 1h -cps 10 \
  -src_ip 192.168.1.10 -dst_ip 192.168.1.20 \
  -fail_ratio 0.05 \
  -sbc_log_file calls.jsonl
```

## Test plan

- [x] All 12 new backfill tests pass (`go test ./internal/backfill/ -v`)
- [x] Full suite `go test ./...` — zero regressions (3 pre-existing `ui` transport failures confirmed on `main`)
- [x] `go vet` clean on all new/modified packages
- [x] End-to-end CLI run verified: logs and metrics output validated as correct JSON-Lines with past timestamps