### PR TITLE
feat(scenario): Add distribution support for pause command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ incremental XML scenario compatibility, and a cleaner engine architecture.
 The current MVP implements:
 
 - XML scenarios with `send`, `recv`, `pause`, `nop`, `label`, `timewait`, and `init`
+- `<pause>` command with `distribution` attribute for `fixed`, `uniform`, and `normal` distributions
 - XML command handoff via `sendCmd` / `recvCmd`, both inside one `Gossipper` process and across multiple instances
 - SIPp-style 3PCC CLI aliases `-master`, `-slave`, and `-slave_cfg` on top of the external command transport
 - Out-of-call SIP scenarios such as stateless `OPTIONS` ping/pong

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -35,14 +35,22 @@ func NewFromXML(distType, milliseconds, mean, stdev, min, max string) (Sampler, 
 		if strings.TrimSpace(max) == "" {
 			return nil, fmt.Errorf("uniform distribution: max attribute is required")
 		}
-		minMs, err := parseDurationMs(min)
+		minFloat, err := parseFloat(min)
 		if err != nil {
 			return nil, fmt.Errorf("uniform distribution: invalid min: %w", err)
 		}
-		maxMs, err := parseDurationMs(max)
+		maxFloat, err := parseFloat(max)
 		if err != nil {
 			return nil, fmt.Errorf("uniform distribution: invalid max: %w", err)
 		}
+		if minFloat < 0 {
+			return nil, fmt.Errorf("uniform distribution: min must be non-negative")
+		}
+		if maxFloat < 0 {
+			return nil, fmt.Errorf("uniform distribution: max must be non-negative")
+		}
+		minMs := time.Duration(minFloat * float64(time.Millisecond))
+		maxMs := time.Duration(maxFloat * float64(time.Millisecond))
 		if minMs > maxMs {
 			return nil, fmt.Errorf("uniform distribution: min (%v) cannot be greater than max (%v)", minMs, maxMs)
 		}

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -77,6 +77,9 @@ func NewFromXML(distType, milliseconds, mean, stdev, min, max string) (Sampler, 
 		if stdevFloat < 0 {
 			return nil, fmt.Errorf("normal distribution: stdev must be non-negative")
 		}
+		if meanFloat == 0 && stdevFloat == 0 {
+			return nil, fmt.Errorf("normal distribution: mean and stdev cannot both be zero")
+		}
 		return &Normal{
 			Mean:  time.Duration(meanFloat * float64(time.Millisecond)),
 			Stdev: time.Duration(stdevFloat * float64(time.Millisecond)),

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -1,0 +1,147 @@
+package distribution
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Sampler defines an interface for sampling a duration.
+type Sampler interface {
+	Sample() time.Duration
+}
+
+// NewFromXML creates a new Sampler from XML attributes.
+// This acts as a factory and keeps the parsing logic contained within this package.
+func NewFromXML(distType, milliseconds, mean, stdev, min, max string) (Sampler, error) {
+	if distType == "" {
+		distType = "fixed"
+	}
+
+	switch strings.ToLower(distType) {
+	case "fixed":
+		ms, err := parseDurationMs(milliseconds)
+		if err != nil {
+			return nil, fmt.Errorf("fixed distribution: invalid milliseconds: %w", err)
+		}
+		return &Fixed{Value: ms}, nil
+
+	case "uniform":
+		if strings.TrimSpace(min) == "" {
+			return nil, fmt.Errorf("uniform distribution: min attribute is required")
+		}
+		if strings.TrimSpace(max) == "" {
+			return nil, fmt.Errorf("uniform distribution: max attribute is required")
+		}
+		minMs, err := parseDurationMs(min)
+		if err != nil {
+			return nil, fmt.Errorf("uniform distribution: invalid min: %w", err)
+		}
+		maxMs, err := parseDurationMs(max)
+		if err != nil {
+			return nil, fmt.Errorf("uniform distribution: invalid max: %w", err)
+		}
+		if minMs > maxMs {
+			return nil, fmt.Errorf("uniform distribution: min (%v) cannot be greater than max (%v)", minMs, maxMs)
+		}
+		return &Uniform{Min: minMs, Max: maxMs}, nil
+
+	case "normal":
+		if strings.TrimSpace(mean) == "" {
+			return nil, fmt.Errorf("normal distribution: mean attribute is required")
+		}
+		if strings.TrimSpace(stdev) == "" {
+			return nil, fmt.Errorf("normal distribution: stdev attribute is required")
+		}
+		meanFloat, err := parseFloat(mean)
+		if err != nil {
+			return nil, fmt.Errorf("normal distribution: invalid mean: %w", err)
+		}
+		stdevFloat, err := parseFloat(stdev)
+		if err != nil {
+			return nil, fmt.Errorf("normal distribution: invalid stdev: %w", err)
+		}
+		if meanFloat < 0 {
+			return nil, fmt.Errorf("normal distribution: mean must be non-negative")
+		}
+		if stdevFloat < 0 {
+			return nil, fmt.Errorf("normal distribution: stdev must be non-negative")
+		}
+		return &Normal{
+			Mean:  time.Duration(meanFloat * float64(time.Millisecond)),
+			Stdev: time.Duration(stdevFloat * float64(time.Millisecond)),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported distribution type: %q", distType)
+	}
+}
+
+// Fixed distribution returns a constant value.
+type Fixed struct {
+	Value time.Duration
+}
+
+// Sample returns the fixed duration.
+func (f *Fixed) Sample() time.Duration {
+	return f.Value
+}
+
+// Uniform distribution returns a random value within a range.
+type Uniform struct {
+	Min, Max time.Duration
+}
+
+// Sample returns a random duration between Min and Max.
+func (u *Uniform) Sample() time.Duration {
+	if u.Min >= u.Max {
+		return u.Min
+	}
+	// rand.Int63n works with int64, so we convert durations to nanoseconds.
+	minNs := u.Min.Nanoseconds()
+	maxNs := u.Max.Nanoseconds()
+	delta := maxNs - minNs
+	return time.Duration(minNs + rand.Int63n(delta))
+}
+
+// Normal distribution (Gaussian).
+type Normal struct {
+	Mean, Stdev time.Duration
+}
+
+// Sample returns a normally distributed random duration.
+// The result is capped at 0 to prevent negative durations.
+func (n *Normal) Sample() time.Duration {
+	// Use rand.NormFloat64 which gives a normal distribution with mean 0 and stdev 1.
+	// We then scale and shift it.
+	sample := rand.NormFloat64()*float64(n.Stdev) + float64(n.Mean)
+	if sample < 0 {
+		return 0
+	}
+	return time.Duration(sample)
+}
+
+func parseDurationMs(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	ms, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+	if ms < 0 {
+		return 0, fmt.Errorf("duration cannot be negative: %d", ms)
+	}
+	return time.Duration(ms) * time.Millisecond, nil
+}
+
+func parseFloat(value string) (float64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	return strconv.ParseFloat(value, 64)
+}

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -10,7 +10,7 @@ import (
 
 // Sampler defines an interface for sampling a duration.
 type Sampler interface {
-	Sample() time.Duration
+	Sample(rng *rand.Rand) time.Duration
 }
 
 // NewFromXML creates a new Sampler from XML attributes.
@@ -93,7 +93,7 @@ type Fixed struct {
 }
 
 // Sample returns the fixed duration.
-func (f *Fixed) Sample() time.Duration {
+func (f *Fixed) Sample(rng *rand.Rand) time.Duration {
 	return f.Value
 }
 
@@ -103,7 +103,7 @@ type Uniform struct {
 }
 
 // Sample returns a random duration between Min and Max.
-func (u *Uniform) Sample() time.Duration {
+func (u *Uniform) Sample(rng *rand.Rand) time.Duration {
 	if u.Min >= u.Max {
 		return u.Min
 	}
@@ -111,7 +111,7 @@ func (u *Uniform) Sample() time.Duration {
 	minNs := u.Min.Nanoseconds()
 	maxNs := u.Max.Nanoseconds()
 	delta := maxNs - minNs
-	return time.Duration(minNs + rand.Int63n(delta))
+	return time.Duration(minNs + rng.Int63n(delta))
 }
 
 // Normal distribution (Gaussian).
@@ -121,10 +121,10 @@ type Normal struct {
 
 // Sample returns a normally distributed random duration.
 // The result is capped at 0 to prevent negative durations.
-func (n *Normal) Sample() time.Duration {
+func (n *Normal) Sample(rng *rand.Rand) time.Duration {
 	// Use rand.NormFloat64 which gives a normal distribution with mean 0 and stdev 1.
 	// We then scale and shift it.
-	sample := rand.NormFloat64()*float64(n.Stdev) + float64(n.Mean)
+	sample := rng.NormFloat64()*float64(n.Stdev) + float64(n.Mean)
 	if sample < 0 {
 		return 0
 	}

--- a/internal/distribution/distribution_test.go
+++ b/internal/distribution/distribution_test.go
@@ -137,6 +137,13 @@ func TestNewFromXML(t *testing.T) {
 			wantErr:  "normal distribution: stdev must be non-negative",
 		},
 		{
+			name:     "normal both mean and stdev zero is rejected",
+			distType: "normal",
+			mean:     "0",
+			stdev:    "0",
+			wantErr:  "normal distribution: mean and stdev cannot both be zero",
+		},
+		{
 			name:     "normal empty mean is rejected",
 			distType: "normal",
 			mean:     "",

--- a/internal/distribution/distribution_test.go
+++ b/internal/distribution/distribution_test.go
@@ -1,0 +1,201 @@
+package distribution
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewFromXML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		distType    string
+		ms          string
+		mean        string
+		stdev       string
+		min         string
+		max         string
+		wantErr     string
+		assertValue func(t *testing.T, sampler Sampler)
+	}{
+		{
+			name:     "default fixed distribution",
+			distType: "",
+			ms:       "150",
+			assertValue: func(t *testing.T, sampler Sampler) {
+				t.Helper()
+				got, ok := sampler.(*Fixed)
+				if !ok {
+					t.Fatalf("expected *Fixed, got %T", sampler)
+				}
+				if got.Value != 150*time.Millisecond {
+					t.Fatalf("expected 150ms, got %v", got.Value)
+				}
+			},
+		},
+		{
+			name:     "uniform distribution",
+			distType: "uniform",
+			min:      "25",
+			max:      "75",
+			assertValue: func(t *testing.T, sampler Sampler) {
+				t.Helper()
+				got, ok := sampler.(*Uniform)
+				if !ok {
+					t.Fatalf("expected *Uniform, got %T", sampler)
+				}
+				if got.Min != 25*time.Millisecond || got.Max != 75*time.Millisecond {
+					t.Fatalf("unexpected bounds: min=%v max=%v", got.Min, got.Max)
+				}
+			},
+		},
+		{
+			name:     "normal distribution supports fractional milliseconds",
+			distType: "normal",
+			mean:     "100.5",
+			stdev:    "7.25",
+			assertValue: func(t *testing.T, sampler Sampler) {
+				t.Helper()
+				got, ok := sampler.(*Normal)
+				if !ok {
+					t.Fatalf("expected *Normal, got %T", sampler)
+				}
+				if got.Mean != 100500000*time.Nanosecond {
+					t.Fatalf("expected mean 100.5ms, got %v", got.Mean)
+				}
+				if got.Stdev != 7250000*time.Nanosecond {
+					t.Fatalf("expected stdev 7.25ms, got %v", got.Stdev)
+				}
+			},
+		},
+		{
+			name:     "unsupported distribution",
+			distType: "triangle",
+			wantErr:  "unsupported distribution type",
+		},
+		{
+			name:     "fixed invalid milliseconds",
+			distType: "fixed",
+			ms:       "abc",
+			wantErr:  "fixed distribution: invalid milliseconds",
+		},
+		{
+			name:     "uniform min greater than max",
+			distType: "uniform",
+			min:      "20",
+			max:      "10",
+			wantErr:  "uniform distribution: min",
+		},
+		{
+			name:     "normal negative mean",
+			distType: "normal",
+			mean:     "-1",
+			stdev:    "1",
+			wantErr:  "normal distribution: mean must be non-negative",
+		},
+		{
+			name:     "normal negative stdev",
+			distType: "normal",
+			mean:     "1",
+			stdev:    "-1",
+			wantErr:  "normal distribution: stdev must be non-negative",
+		},
+		{
+			name:     "normal empty mean is rejected",
+			distType: "normal",
+			mean:     "",
+			stdev:    "10",
+			wantErr:  "normal distribution: mean attribute is required",
+		},
+		{
+			name:     "normal empty stdev is rejected",
+			distType: "normal",
+			mean:     "100",
+			stdev:    "",
+			wantErr:  "normal distribution: stdev attribute is required",
+		},
+		{
+			name:     "uniform empty min is rejected",
+			distType: "uniform",
+			min:      "",
+			max:      "100",
+			wantErr:  "uniform distribution: min attribute is required",
+		},
+		{
+			name:     "uniform empty max is rejected",
+			distType: "uniform",
+			min:      "10",
+			max:      "",
+			wantErr:  "uniform distribution: max attribute is required",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sampler, err := NewFromXML(tt.distType, tt.ms, tt.mean, tt.stdev, tt.min, tt.max)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.assertValue != nil {
+				tt.assertValue(t, sampler)
+			}
+		})
+	}
+}
+
+func TestFixedSample(t *testing.T) {
+	t.Parallel()
+
+	s := &Fixed{Value: 42 * time.Millisecond}
+	if got := s.Sample(); got != 42*time.Millisecond {
+		t.Fatalf("expected 42ms, got %v", got)
+	}
+}
+
+func TestUniformSample(t *testing.T) {
+	t.Parallel()
+
+	t.Run("equal bounds", func(t *testing.T) {
+		t.Parallel()
+		s := &Uniform{Min: 30 * time.Millisecond, Max: 30 * time.Millisecond}
+		if got := s.Sample(); got != 30*time.Millisecond {
+			t.Fatalf("expected 30ms, got %v", got)
+		}
+	})
+
+	t.Run("sample stays within range", func(t *testing.T) {
+		t.Parallel()
+		s := &Uniform{Min: 10 * time.Millisecond, Max: 20 * time.Millisecond}
+		for i := 0; i < 100; i++ {
+			got := s.Sample()
+			if got < 10*time.Millisecond || got >= 20*time.Millisecond {
+				t.Fatalf("sample out of range: %v", got)
+			}
+		}
+	})
+}
+
+func TestNormalSample(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns mean when stdev is zero", func(t *testing.T) {
+		t.Parallel()
+		s := &Normal{Mean: 12 * time.Millisecond, Stdev: 0}
+		if got := s.Sample(); got != 12*time.Millisecond {
+			t.Fatalf("expected 12ms, got %v", got)
+		}
+	})
+}

--- a/internal/distribution/distribution_test.go
+++ b/internal/distribution/distribution_test.go
@@ -52,6 +52,25 @@ func TestNewFromXML(t *testing.T) {
 			},
 		},
 		{
+			name:     "uniform distribution supports fractional milliseconds",
+			distType: "uniform",
+			min:      "10.5",
+			max:      "20.75",
+			assertValue: func(t *testing.T, sampler Sampler) {
+				t.Helper()
+				got, ok := sampler.(*Uniform)
+				if !ok {
+					t.Fatalf("expected *Uniform, got %T", sampler)
+				}
+				if got.Min != 10500000*time.Nanosecond {
+					t.Fatalf("expected min 10.5ms, got %v", got.Min)
+				}
+				if got.Max != 20750000*time.Nanosecond {
+					t.Fatalf("expected max 20.75ms, got %v", got.Max)
+				}
+			},
+		},
+		{
 			name:     "normal distribution supports fractional milliseconds",
 			distType: "normal",
 			mean:     "100.5",
@@ -87,6 +106,20 @@ func TestNewFromXML(t *testing.T) {
 			min:      "20",
 			max:      "10",
 			wantErr:  "uniform distribution: min",
+		},
+		{
+			name:     "uniform negative min",
+			distType: "uniform",
+			min:      "-5",
+			max:      "10",
+			wantErr:  "uniform distribution: min must be non-negative",
+		},
+		{
+			name:     "uniform negative max",
+			distType: "uniform",
+			min:      "5",
+			max:      "-10",
+			wantErr:  "uniform distribution: max must be non-negative",
 		},
 		{
 			name:     "normal negative mean",

--- a/internal/distribution/distribution_test.go
+++ b/internal/distribution/distribution_test.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -192,8 +193,9 @@ func TestNewFromXML(t *testing.T) {
 func TestFixedSample(t *testing.T) {
 	t.Parallel()
 
+	rng := rand.New(rand.NewSource(42))
 	s := &Fixed{Value: 42 * time.Millisecond}
-	if got := s.Sample(); got != 42*time.Millisecond {
+	if got := s.Sample(rng); got != 42*time.Millisecond {
 		t.Fatalf("expected 42ms, got %v", got)
 	}
 }
@@ -203,17 +205,19 @@ func TestUniformSample(t *testing.T) {
 
 	t.Run("equal bounds", func(t *testing.T) {
 		t.Parallel()
+		rng := rand.New(rand.NewSource(42))
 		s := &Uniform{Min: 30 * time.Millisecond, Max: 30 * time.Millisecond}
-		if got := s.Sample(); got != 30*time.Millisecond {
+		if got := s.Sample(rng); got != 30*time.Millisecond {
 			t.Fatalf("expected 30ms, got %v", got)
 		}
 	})
 
 	t.Run("sample stays within range", func(t *testing.T) {
 		t.Parallel()
+		rng := rand.New(rand.NewSource(42))
 		s := &Uniform{Min: 10 * time.Millisecond, Max: 20 * time.Millisecond}
 		for i := 0; i < 100; i++ {
-			got := s.Sample()
+			got := s.Sample(rng)
 			if got < 10*time.Millisecond || got >= 20*time.Millisecond {
 				t.Fatalf("sample out of range: %v", got)
 			}
@@ -226,8 +230,9 @@ func TestNormalSample(t *testing.T) {
 
 	t.Run("returns mean when stdev is zero", func(t *testing.T) {
 		t.Parallel()
+		rng := rand.New(rand.NewSource(42))
 		s := &Normal{Mean: 12 * time.Millisecond, Stdev: 0}
-		if got := s.Sample(); got != 12*time.Millisecond {
+		if got := s.Sample(rng); got != 12*time.Millisecond {
 			t.Fatalf("expected 12ms, got %v", got)
 		}
 	})

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1609,7 +1609,9 @@ func (e *Engine) executeCall(
 		case scenario.CommandPause, scenario.CommandTimeWait:
 			var pause time.Duration
 			if cmd.Pause != nil {
-				pause = cmd.Pause.Sample()
+				e.randomMu.Lock()
+				pause = cmd.Pause.Sample(e.random)
+				e.randomMu.Unlock()
 			}
 			if pause <= 0 {
 				pause = e.cfg.DefaultPause

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1607,7 +1607,10 @@ func (e *Engine) executeCall(
 				continue
 			}
 		case scenario.CommandPause, scenario.CommandTimeWait:
-			pause := cmd.Pause
+			var pause time.Duration
+			if cmd.Pause != nil {
+				pause = cmd.Pause.Sample()
+			}
 			if pause <= 0 {
 				pause = e.cfg.DefaultPause
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 	"github.com/pion/rtcp"
+	"github.com/sipcapture/gossipper/internal/distribution"
 	"github.com/sipcapture/gossipper/internal/hep"
 	"github.com/sipcapture/gossipper/internal/media"
 
@@ -1888,6 +1889,34 @@ func TestEngineUACPauseDistribution(t *testing.T) {
 		t.Fatalf("ParseFile() error = %v", err)
 	}
 
+	// Verify that the pause commands were parsed with the correct sampler types
+	var uniformPauseFound, normalPauseFound bool
+	for _, cmd := range sc.Commands {
+		if cmd.Type == scenario.CommandPause && cmd.Pause != nil {
+			switch cmd.Pause.(type) {
+			case *distribution.Uniform:
+				uniformPauseFound = true
+				u := cmd.Pause.(*distribution.Uniform)
+				if u.Min != 50*time.Millisecond || u.Max != 150*time.Millisecond {
+					t.Fatalf("uniform pause has wrong bounds: min=%v max=%v", u.Min, u.Max)
+				}
+			case *distribution.Normal:
+				normalPauseFound = true
+				n := cmd.Pause.(*distribution.Normal)
+				if n.Mean != 100*time.Millisecond || n.Stdev != 10*time.Millisecond {
+					t.Fatalf("normal pause has wrong parameters: mean=%v stdev=%v", n.Mean, n.Stdev)
+				}
+			}
+		}
+	}
+	if !uniformPauseFound {
+		t.Fatal("uniform distribution pause not found in parsed scenario")
+	}
+	if !normalPauseFound {
+		t.Fatal("normal distribution pause not found in parsed scenario")
+	}
+
+	startTime := time.Now()
 	app := New(Config{
 		Scenario:      sc,
 		Transport:     "u1",
@@ -1909,6 +1938,7 @@ func TestEngineUACPauseDistribution(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	<-done
+	elapsed := time.Since(startTime)
 
 	summary := app.Stats().Snapshot()
 	if summary.SuccessCalls != 1 {
@@ -1916,6 +1946,18 @@ func TestEngineUACPauseDistribution(t *testing.T) {
 	}
 	if summary.FailedCalls != 0 {
 		t.Fatalf("expected zero failed calls, got %+v", summary)
+	}
+
+	// Verify that the pauses were actually sampled (not falling back to DefaultPause).
+	// The scenario has two pauses:
+	// 1. uniform(50-150ms) after receiving 200 OK
+	// 2. normal(mean=100ms, stdev=10ms) after ACK
+	// Total expected pause time: ~150-250ms (50+100 to 150+100, roughly)
+	// If samplers were bypassed and DefaultPause (10ms) was used, total would be ~20ms.
+	// We check that elapsed time is at least 100ms to confirm samplers were used.
+	minExpectedDuration := 100 * time.Millisecond
+	if elapsed < minExpectedDuration {
+		t.Fatalf("call completed too quickly (%v), suggesting pauses were not sampled (expected at least %v)", elapsed, minExpectedDuration)
 	}
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1833,6 +1833,92 @@ Content-Length: 0
 	}
 }
 
+func TestEngineUACPauseDistribution(t *testing.T) {
+	t.Parallel()
+
+	serverConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP() error = %v", err)
+	}
+	defer serverConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buffer := make([]byte, 65535)
+		for {
+			_ = serverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			n, addr, err := serverConn.ReadFromUDP(buffer)
+			if err != nil {
+				return
+			}
+			msg := sip.GetMessage()
+			defer sip.PutMessage(msg)
+			if err := sip.ParseInto(msg, buffer[:n]); err != nil {
+				return
+			}
+			callID, _ := sip.Header(msg.Headers, "Call-ID")
+			from, _ := sip.Header(msg.Headers, "From")
+			to, _ := sip.Header(msg.Headers, "To")
+			via, _ := sip.Header(msg.Headers, "Via")
+			cseq, _ := sip.Header(msg.Headers, "CSeq")
+
+			switch strings.ToUpper(msg.Method) {
+			case "INVITE":
+				response := fmt.Sprintf(
+					"SIP/2.0 200 OK\r\nVia: %s\r\nFrom: %s\r\nTo: %s;tag=peer\r\nCall-ID: %s\r\nCSeq: %s\r\nContact: <sip:127.0.0.1:%d>\r\nContent-Length: 0\r\n\r\n",
+					via, from, to, callID, cseq, serverConn.LocalAddr().(*net.UDPAddr).Port,
+				)
+				_, _ = serverConn.WriteToUDP([]byte(response), addr)
+			case "ACK":
+				// OK
+			case "BYE":
+				response := fmt.Sprintf(
+					"SIP/2.0 200 OK\r\nVia: %s\r\nFrom: %s\r\nTo: %s\r\nCall-ID: %s\r\nCSeq: %s\r\nContent-Length: 0\r\n\r\n",
+					via, from, to, callID, cseq,
+				)
+				_, _ = serverConn.WriteToUDP([]byte(response), addr)
+				return
+			}
+		}
+	}()
+
+	sc, err := scenario.ParseFile("../../testdata/scenarios/uac_pause_distribution.xml")
+	if err != nil {
+		t.Fatalf("ParseFile() error = %v", err)
+	}
+
+	app := New(Config{
+		Scenario:      sc,
+		Transport:     "u1",
+		LocalIP:       "127.0.0.1",
+		RemoteHost:    "127.0.0.1",
+		RemotePort:    serverConn.LocalAddr().(*net.UDPAddr).Port,
+		Service:       "echo",
+		Rate:          100,
+		TotalCalls:    1,
+		MaxConcurrent: 1,
+		DefaultPause:  10 * time.Millisecond,
+		DefaultRecvTO: time.Second,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	if err := app.Run(ctx); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	<-done
+
+	summary := app.Stats().Snapshot()
+	if summary.SuccessCalls != 1 {
+		t.Fatalf("expected one successful call, got %+v", summary)
+	}
+	if summary.FailedCalls != 0 {
+		t.Fatalf("expected zero failed calls, got %+v", summary)
+	}
+}
+
 func TestEngineAppliesStrCmpAndExtendedTestComparisons(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -125,7 +125,9 @@ func (e *Engine) runInit(ctx context.Context) error {
 		case scenario.CommandPause, scenario.CommandTimeWait:
 			var pause time.Duration
 			if cmd.Pause != nil {
-				pause = cmd.Pause.Sample()
+				e.randomMu.Lock()
+				pause = cmd.Pause.Sample(e.random)
+				e.randomMu.Unlock()
 			}
 			if pause <= 0 {
 				pause = e.cfg.DefaultPause

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -123,7 +123,10 @@ func (e *Engine) runInit(ctx context.Context) error {
 				continue
 			}
 		case scenario.CommandPause, scenario.CommandTimeWait:
-			pause := cmd.Pause
+			var pause time.Duration
+			if cmd.Pause != nil {
+				pause = cmd.Pause.Sample()
+			}
 			if pause <= 0 {
 				pause = e.cfg.DefaultPause
 			}

--- a/internal/scenario/model.go
+++ b/internal/scenario/model.go
@@ -1,6 +1,10 @@
 package scenario
 
-import "time"
+import (
+	"time"
+
+	"github.com/sipcapture/gossipper/internal/distribution"
+)
 
 type CommandType string
 
@@ -116,7 +120,7 @@ type Command struct {
 	CmdSrc   string
 	Optional bool
 	Timeout  time.Duration
-	Pause    time.Duration
+	Pause    distribution.Sampler
 	LabelID  string
 	TimeWait bool
 	Actions  []Action

--- a/internal/scenario/parser.go
+++ b/internal/scenario/parser.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sipcapture/gossipper/internal/distribution"
 	"golang.org/x/text/encoding/charmap"
 )
 
@@ -49,6 +50,11 @@ type rawScenarioItem struct {
 	Variables       string       `xml:"variables,attr"`
 	Actions         []rawAction  `xml:"action"`
 	Elements        []rawElement `xml:",any"`
+	Distribution    string       `xml:"distribution,attr"`
+	Mean            string       `xml:"mean,attr"`
+	Stdev           string       `xml:"stdev,attr"`
+	Min             string       `xml:"min,attr"`
+	Max             string       `xml:"max,attr"`
 }
 
 type rawElement struct {
@@ -74,6 +80,11 @@ type rawElement struct {
 	Dest            string      `xml:"dest,attr"`
 	Src             string      `xml:"src,attr"`
 	Actions         []rawAction `xml:"action"`
+	Distribution    string      `xml:"distribution,attr"`
+	Mean            string      `xml:"mean,attr"`
+	Stdev           string      `xml:"stdev,attr"`
+	Min             string      `xml:"min,attr"`
+	Max             string      `xml:"max,attr"`
 }
 
 type rawAction struct {
@@ -229,6 +240,11 @@ func rawScenarioItemToCommand(elem rawScenarioItem, index int) (Command, error) 
 		Dest:            elem.Dest,
 		Src:             elem.Src,
 		Actions:         elem.Actions,
+		Distribution:    elem.Distribution,
+		Mean:            elem.Mean,
+		Stdev:           elem.Stdev,
+		Min:             elem.Min,
+		Max:             elem.Max,
 	}, index)
 }
 
@@ -262,7 +278,18 @@ func rawElementToCommand(elem rawElement, index int) (Command, error) {
 		cmd.Timeout = parseDurationMilliseconds(elem.Timeout)
 	case "pause":
 		cmd.Type = CommandPause
-		cmd.Pause = parseDurationMilliseconds(elem.Milliseconds)
+		sampler, err := distribution.NewFromXML(
+			elem.Distribution,
+			elem.Milliseconds,
+			elem.Mean,
+			elem.Stdev,
+			elem.Min,
+			elem.Max,
+		)
+		if err != nil {
+			return Command{}, fmt.Errorf("pause at index %d: %w", index, err)
+		}
+		cmd.Pause = sampler
 	case "nop":
 		cmd.Type = CommandNop
 	case "label":
@@ -271,7 +298,15 @@ func rawElementToCommand(elem rawElement, index int) (Command, error) {
 	case "timewait":
 		cmd.Type = CommandTimeWait
 		cmd.TimeWait = true
-		cmd.Pause = parseDurationMilliseconds(elem.Milliseconds)
+		sampler, err := distribution.NewFromXML(
+			"fixed",
+			elem.Milliseconds,
+			"", "", "", "",
+		)
+		if err != nil {
+			return Command{}, fmt.Errorf("timewait at index %d: %w", index, err)
+		}
+		cmd.Pause = sampler
 	default:
 		return Command{}, nil
 	}

--- a/internal/scenario/parser.go
+++ b/internal/scenario/parser.go
@@ -19,6 +19,15 @@ func ErrUnknownScenario(name string) error {
 	return fmt.Errorf("unknown built-in scenario %q", name)
 }
 
+// rawDistributionAttrs holds XML attributes for pause distribution configuration.
+type rawDistributionAttrs struct {
+	Distribution string `xml:"distribution,attr"`
+	Mean         string `xml:"mean,attr"`
+	Stdev        string `xml:"stdev,attr"`
+	Min          string `xml:"min,attr"`
+	Max          string `xml:"max,attr"`
+}
+
 type rawScenario struct {
 	XMLName  xml.Name          `xml:"scenario"`
 	Name     string            `xml:"name,attr"`
@@ -50,11 +59,7 @@ type rawScenarioItem struct {
 	Variables       string       `xml:"variables,attr"`
 	Actions         []rawAction  `xml:"action"`
 	Elements        []rawElement `xml:",any"`
-	Distribution    string       `xml:"distribution,attr"`
-	Mean            string       `xml:"mean,attr"`
-	Stdev           string       `xml:"stdev,attr"`
-	Min             string       `xml:"min,attr"`
-	Max             string       `xml:"max,attr"`
+	rawDistributionAttrs
 }
 
 type rawElement struct {
@@ -80,11 +85,7 @@ type rawElement struct {
 	Dest            string      `xml:"dest,attr"`
 	Src             string      `xml:"src,attr"`
 	Actions         []rawAction `xml:"action"`
-	Distribution    string      `xml:"distribution,attr"`
-	Mean            string      `xml:"mean,attr"`
-	Stdev           string      `xml:"stdev,attr"`
-	Min             string      `xml:"min,attr"`
-	Max             string      `xml:"max,attr"`
+	rawDistributionAttrs
 }
 
 type rawAction struct {
@@ -218,33 +219,29 @@ func ParseString(data string) (Scenario, error) {
 
 func rawScenarioItemToCommand(elem rawScenarioItem, index int) (Command, error) {
 	return rawElementToCommand(rawElement{
-		XMLName:         elem.XMLName,
-		Text:            elem.Text,
-		Next:            elem.Next,
-		Test:            elem.Test,
-		Chance:          elem.Chance,
-		CondExec:        elem.CondExec,
-		CondExecInverse: elem.CondExecInverse,
-		Counter:         elem.Counter,
-		Display:         elem.Display,
-		StartRTD:        elem.StartRTD,
-		RTD:             elem.RTD,
-		Retrans:         elem.Retrans,
-		Request:         elem.Request,
-		Response:        elem.Response,
-		RRS:             elem.RRS,
-		Optional:        elem.Optional,
-		Timeout:         elem.Timeout,
-		Milliseconds:    elem.Milliseconds,
-		ID:              elem.ID,
-		Dest:            elem.Dest,
-		Src:             elem.Src,
-		Actions:         elem.Actions,
-		Distribution:    elem.Distribution,
-		Mean:            elem.Mean,
-		Stdev:           elem.Stdev,
-		Min:             elem.Min,
-		Max:             elem.Max,
+		XMLName:              elem.XMLName,
+		Text:                 elem.Text,
+		Next:                 elem.Next,
+		Test:                 elem.Test,
+		Chance:               elem.Chance,
+		CondExec:             elem.CondExec,
+		CondExecInverse:      elem.CondExecInverse,
+		Counter:              elem.Counter,
+		Display:              elem.Display,
+		StartRTD:             elem.StartRTD,
+		RTD:                  elem.RTD,
+		Retrans:              elem.Retrans,
+		Request:              elem.Request,
+		Response:             elem.Response,
+		RRS:                  elem.RRS,
+		Optional:             elem.Optional,
+		Timeout:              elem.Timeout,
+		Milliseconds:         elem.Milliseconds,
+		ID:                   elem.ID,
+		Dest:                 elem.Dest,
+		Src:                  elem.Src,
+		Actions:              elem.Actions,
+		rawDistributionAttrs: elem.rawDistributionAttrs,
 	}, index)
 }
 

--- a/testdata/scenarios/uac_pause_distribution.xml
+++ b/testdata/scenarios/uac_pause_distribution.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<scenario name="uac-pause-distribution">
+  <send>
+    <![CDATA[
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_id]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+    ]]>
+  </send>
+  <recv response="100" optional="true"></recv>
+  <recv response="180" optional="true"></recv>
+  <recv response="183" optional="true"></recv>
+  <recv response="200" rtd="true"></recv>
+  <pause distribution="uniform" min="50" max="150" />
+  <send>
+    <![CDATA[
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_id]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Length: 0
+    ]]>
+  </send>
+  <pause distribution="normal" mean="100" stdev="10" />
+  <send>
+    <![CDATA[
+      BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_id]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 2 BYE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Length: 0
+    ]]>
+  </send>
+  <recv response="200" crlf="true"></recv>
+</scenario>


### PR DESCRIPTION
This commit introduces support for probabilistic distributions in the `<pause>` scenario command, allowing for more realistic simulation of user behavior.
The following distributions from `sipp` are supported:

1.  - `fixed`: The default, using the `milliseconds` attribute.
2.  - `uniform`: Using `min` and `max` attributes.
3.  - `normal`: Using `mean` and `stdev` attributes.

This is implemented through a new modular `internal/distribution` package, which contains a `Sampler` interface and the concrete distribution implementations. The scenario parser and engine have been updated to use this new system.
An integration test with a new scenario (`uac_pause_distribution.xml`) has been added to verify the functionality.
