### PR TITLE
refactor(media): extract udpSendBatchFallback

### DIFF
--- a/internal/media/scale_send_other.go
+++ b/internal/media/scale_send_other.go
@@ -11,6 +11,10 @@ type udpSendMsg struct {
 }
 
 func udpSendBatch(conn *net.UDPConn, msgs []udpSendMsg) (int, error) {
+	return udpSendBatchFallback(conn, msgs)
+}
+
+func udpSendBatchFallback(conn *net.UDPConn, msgs []udpSendMsg) (int, error) {
 	sent := 0
 	for _, m := range msgs {
 		if _, err := conn.WriteTo(m.Buf, m.Addr); err != nil {


### PR DESCRIPTION
Move the per-message WriteTo loop from udpSendBatch into a dedicated udpSendBatchFallback function. udpSendBatch on non-Linux platforms delegates to it, making the fallback path explicitly named and reusable. 

No behaviour change.

Fixing #20 