### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/internal/uistore/store.go
+++ b/internal/uistore/store.go
@@ -603,6 +603,12 @@ func (s *Store) pruneScenarioHistoryLocked(id string) error {
 	if err != nil {
 		return err
 	}
+	scenariosRoot := filepath.Clean(s.layout.ScenariosDir())
+	dir = filepath.Clean(dir)
+	rel, err := filepath.Rel(scenariosRoot, dir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("uistore: invalid history directory")
+	}
 	entries, err := listScenarioHistoryEntriesFromDir(dir)
 	if err != nil {
 		return err
@@ -618,7 +624,7 @@ func (s *Store) pruneScenarioHistoryLocked(id string) error {
 // listScenarioHistoryEntriesFromDir scans dir for *.xml snapshots, newest first.
 func listScenarioHistoryEntriesFromDir(dir string) ([]ScenarioHistoryEntry, error) {
 	dir = filepath.Clean(strings.TrimSpace(dir))
-	if dir == "." || dir == "" || filepath.IsAbs(dir) {
+	if dir == "." || dir == "" {
 		return nil, fmt.Errorf("uistore: invalid history directory")
 	}
 	entries, err := os.ReadDir(dir)


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/gossipper/security/code-scanning/24](https://github.com/sipcapture/gossipper/security/code-scanning/24)

Use **path containment validation** at the point where history directory paths are consumed.  
Best fix without changing functionality: in `internal/uistore/store.go`, harden `pruneScenarioHistoryLocked` by resolving both:
- the expected base directory (`s.layout.ScenariosDir()`), and
- the computed history directory (`dir`),
then ensure `dir` is inside the base before any delete operations.

Also fix `listScenarioHistoryEntriesFromDir` so it no longer rejects absolute paths (current check is incorrect for this codebase), and instead only rejects empty/`.` and safely reads the provided directory.

This keeps existing behavior, but enforces a robust invariant: even if `id` validation is weakened later, deletes cannot escape the scenarios tree.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
