### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/internal/uistore/layout.go
+++ b/internal/uistore/layout.go
@@ -83,7 +83,13 @@ func (l Layout) ScenarioHistoryDir(id string) (string, error) {
 	if !isSafeID(id) {
 		return "", fmt.Errorf("uistore: invalid scenario id %q", id)
 	}
-	return filepath.Join(l.ScenariosDir(), id+".history"), nil
+	base := filepath.Clean(l.ScenariosDir())
+	candidate := filepath.Clean(filepath.Join(base, id+".history"))
+	rel, err := filepath.Rel(base, candidate)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("uistore: invalid scenario history path for id %q", id)
+	}
+	return candidate, nil
 }
 
 // JobArtifactDir returns the per-job artifact directory; ensures it exists


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/gossipper/security/code-scanning/22](https://github.com/sipcapture/gossipper/security/code-scanning/22)

General fix: after constructing a path from potentially user-influenced components, canonicalize and enforce that the resulting absolute path remains inside an expected safe base directory.

Best fix here (without changing behavior): in `internal/uistore/layout.go`, harden `ScenarioHistoryDir` by resolving both base (`ScenariosDir`) and candidate path to absolute-cleaned paths and verifying candidate is within base using `filepath.Rel` (reject if relative starts with `..` or is absolute). Return an error if containment check fails. This preserves existing API and call sites while adding a defense-in-depth guarantee at the central path-construction point.

Changes needed:
- File: `internal/uistore/layout.go`
- Region: `ScenarioHistoryDir` method.
- No new external dependencies; use existing imports (`filepath`, `strings`, `fmt`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
