### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/internal/api/v2/scenarios.go
+++ b/internal/api/v2/scenarios.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/sipcapture/gossipper/internal/uistore"
@@ -10,6 +11,17 @@ import (
 type scenarioBody struct {
 	uistore.ScenarioMeta
 	XML string `json:"xml"`
+}
+
+func isSafePathID(id string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	if strings.Contains(id, "/") || strings.Contains(id, "\\") || strings.Contains(id, "..") {
+		return false
+	}
+	return filepath.Base(id) == id
 }
 
 func (s *Server) handleListScenarios(w http.ResponseWriter, _ *http.Request) {
@@ -50,6 +62,10 @@ func (s *Server) handleCreateScenario(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if !isSafePathID(body.ID) {
+		s.writeError(w, http.StatusBadRequest, uistore.ErrInvalidID.Error())
+		return
+	}
 	got, err := s.cfg.Store.PutScenario(body.ScenarioMeta, body.XML, true)
 	if err != nil {
 		code, msg := mapStoreError(err)
@@ -69,7 +85,12 @@ func (s *Server) handleUpdateScenario(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	body.ID = pathID(r)
+	id := pathID(r)
+	if !isSafePathID(id) {
+		s.writeError(w, http.StatusBadRequest, uistore.ErrInvalidID.Error())
+		return
+	}
+	body.ID = id
 	got, err := s.cfg.Store.PutScenario(body.ScenarioMeta, body.XML, false)
 	if err != nil {
 		code, msg := mapStoreError(err)


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/gossipper/security/code-scanning/20](https://github.com/sipcapture/gossipper/security/code-scanning/20)

General fix: validate user-controlled IDs as **single safe path components** before passing them into store path construction. Reject IDs containing `/`, `\`, `..`, or values that are not equal to `filepath.Base(id)`.

Best minimal fix without changing behavior:
- In `internal/api/v2/scenarios.go`, after decoding JSON in `handleCreateScenario`, validate `body.ID` with a new helper and return `400` on invalid ID.
- In `handleUpdateScenario`, validate `pathID(r)` before assigning to `body.ID`.
- Add a small local helper `isSafePathID` in the same file using `strings` + `path/filepath`.
This is additive defense-in-depth and helps CodeQL see explicit sanitization close to taint source.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
