### PR TITLE
Potential fix for code scanning alert no. 19: Uncontrolled data used in path expression

### DIFF
--- a/internal/uistore/store.go
+++ b/internal/uistore/store.go
@@ -423,8 +423,22 @@ func (s *Store) GetScenario(id string) (ScenarioBody, error) {
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	baseDirAbs, err := filepath.Abs(s.layout.ScenariosDir())
+	if err != nil {
+		return ScenarioBody{}, err
+	}
 	xmlPath := s.scenarioXMLPath(id)
-	data, err := os.ReadFile(xmlPath)
+	xmlPathAbs, err := filepath.Abs(xmlPath)
+	if err != nil {
+		return ScenarioBody{}, err
+	}
+	basePrefix := baseDirAbs + string(os.PathSeparator)
+	if xmlPathAbs != baseDirAbs && !strings.HasPrefix(xmlPathAbs, basePrefix) {
+		return ScenarioBody{}, ErrInvalidID
+	}
+
+	data, err := os.ReadFile(xmlPathAbs)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return ScenarioBody{}, ErrNotFound


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/gossipper/security/code-scanning/19](https://github.com/sipcapture/gossipper/security/code-scanning/19)

General fix: after constructing a path from potentially user-influenced input, canonicalize and verify the resolved path remains inside an expected safe base directory before file access.

Best concrete fix here: in `internal/uistore/store.go`, harden `GetScenario` by resolving:
- base scenarios directory (`filepath.Abs(s.layout.ScenariosDir())`)
- target XML path (`filepath.Abs(s.scenarioXMLPath(id))`)
Then ensure target is within base (prefix check using `base + string(os.PathSeparator)` or exact equality for safety). If not, return `ErrInvalidID`. This preserves behavior for valid IDs while preventing traversal even if validation weakens.

No new imports are required (uses existing `os` and `filepath`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
