### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/gossipper/security/code-scanning/1](https://github.com/sipcapture/gossipper/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/go.yml` at the workflow root so it applies to all jobs unless overridden. For this workflow, `contents: read` is the minimal and appropriate permission based on current steps (`actions/checkout`, setup actions, and test commands). This change does not alter functional behavior, but it constrains token scope and satisfies the CodeQL finding.

Best single change:
- File: `.github/workflows/go.yml`
- Region: after the `on:` trigger block and before `jobs:`
- Add:
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
