### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/internal/engine/actions_exec.go
+++ b/internal/engine/actions_exec.go
@@ -326,11 +326,11 @@ func parseRTPCheckSpec(raw string, renderCtx templ.Context) (rtpcheckSpec, error
 		return spec, nil
 	}
 	if !strings.Contains(trimmed, "=") {
-		value, err := strconv.Atoi(trimmed)
+		value, err := strconv.ParseUint(trimmed, 10, 32)
 		if err != nil {
 			return rtpcheckSpec{}, fmt.Errorf("rtpcheck value %q must be integer or key=value list", trimmed)
 		}
-		if value <= 0 {
+		if value == 0 {
 			return rtpcheckSpec{}, fmt.Errorf("rtpcheck min packets must be > 0")
 		}
 		spec.minPackets = uint32(value)


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/gossipper/security/code-scanning/5](https://github.com/sipcapture/gossipper/security/code-scanning/5)

Use a parse API that enforces the target bit width directly, instead of parsing to architecture-sized `int` and narrowing later.

Best fix here: in `internal/engine/actions_exec.go`, replace the `Atoi` parse in the non-`key=value` branch with `strconv.ParseUint(trimmed, 10, 32)`, then validate `> 0`, and cast from the returned `uint64` to `uint32`. This preserves behavior (accept positive integers, reject invalid/zero/negative), while removing overflow/truncation risk. No new imports are needed because `strconv` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
