### PR TITLE
docs: SIP Digest CodeQL suppressions and SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.1.64] — 2026-06-05
+
+### Security
+
+- Resolve CodeQL **path-injection** findings via `internal/safepath` helpers (`#30`, `#31`).
+- Document SIP Digest **MD5/SHA-256** false positives (`go/weak-sensitive-data-hashing`) in `SECURITY.md` (`#32`).
+
+### Added
+
+- **macOS** CI build verification and `darwin` release binaries (`make build-darwin`).
+- Client-side scenario XML well-formedness check without `DOMParser` (`web/control-ui/src/lib/xmlValidate.ts`).
+
+### Fixed
+
+- `rtpcheck` `min_packets` parsing: safe `uint32` conversion via `strconv.ParseUint`.
+
 ## [0.1.62] — 2026-05-21
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security
+
+## CodeQL: SIP Digest hashing (`go/weak-sensitive-data-hashing`)
+
+`internal/engine/auth.go` implements **SIP Digest** authentication (RFC 3261, RFC 7616).
+The protocol requires **MD5** and optionally **SHA-256** over credentials material when
+building `Authorization` / `Proxy-Authorization` headers. This is **not** password
+storage or a general-purpose password hash.
+
+CodeQL rule `go/weak-sensitive-data-hashing` reports false positives on `md5Hex` /
+`sha256Hex`. Those call sites are annotated with `// codeql[go/weak-sensitive-data-hashing]`
+and `// lgtm[go/weak-sensitive-data-hashing]` on the line immediately before the hash.
+
+Do not replace MD5/SHA-256 with bcrypt/argon2 here — that would break SIP interoperability.

--- a/cmd/gossip/version.go
+++ b/cmd/gossip/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version   = "0.1.63"
+	Version   = "0.1.64"
 	BuildDate = "1970-01-01"
 	BuildTime = "00:00:00"
 	GitCommit = "unknown"

--- a/internal/engine/auth.go
+++ b/internal/engine/auth.go
@@ -325,15 +325,19 @@ func splitAuthParams(value string) []string {
 	return params
 }
 
+// md5Hex and sha256Hex implement SIP Digest (RFC 3261/7616) response hashing.
+// MD5/SHA-256 are required by those standards — not used for password storage.
+// See SECURITY.md (CodeQL go/weak-sensitive-data-hashing).
+
 func md5Hex(value string) string {
-	// SIP Digest authentication (RFC 3261/7616); not password storage.
+	// lgtm[go/weak-sensitive-data-hashing]
 	// codeql[go/weak-sensitive-data-hashing]
 	sum := md5.Sum([]byte(value))
 	return hex.EncodeToString(sum[:])
 }
 
 func sha256Hex(value string) string {
-	// SIP Digest authentication (RFC 3261/7616); not password storage.
+	// lgtm[go/weak-sensitive-data-hashing]
 	// codeql[go/weak-sensitive-data-hashing]
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])


### PR DESCRIPTION
## Summary

- Document SIP Digest false positives for `go/weak-sensitive-data-hashing` in `SECURITY.md`
- Add `lgtm` + `codeql` suppression markers on digest hash sinks in `auth.go`

Alerts #4 and #42 were dismissed as **won't fix** (protocol-mandated hashing, not password storage).

## Test plan

- [x] `go test ./internal/engine/...`
- [x] [Code scanning](https://github.com/sipcapture/gossipper/security/code-scanning) shows 0 open alerts